### PR TITLE
Harden chunked encoding after adversarial code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,9 @@ By default the manager splits long videos into ~5-minute **chunks** so that mult
 
 **Fallbacks & safety:**
 
-- Videos shorter than ~1.5× the chunk length are encoded whole via the classic path.
+- Videos shorter than ~1.5× the chunk length, VFR sources, and sources whose audio/video streams start at different offsets are encoded whole via the classic path.
 - If a chunk fails 3 times, or assembly fails, the job automatically falls back to whole-file encoding.
-- Chunks with no heartbeat for 30 minutes are handed to another worker; completed chunks are never lost when a worker dies (only the in-flight chunk is redone).
+- Chunks with no heartbeat for 30 minutes are handed to another worker; completed chunks are never lost when a worker dies (only the in-flight chunk is redone). If a split job sees no chunk activity at all for 6 hours (e.g. every chunk-capable worker left), it is returned to the normal queue without penalty.
 - Old workers and the browser-based web worker keep using `/get_job` untouched.
 - Watermarks (`--watermark`) are skipped on chunks so the final video is consistent.
 

--- a/manager.py
+++ b/manager.py
@@ -219,13 +219,19 @@ def log_event(level, message, related_id=None):
         if clean_id:
             clean_id = re.sub(r'[^a-zA-Z0-9_.-]', '', clean_id)
         
+        # NOTE: never call log_event while another connection in the same
+        # thread has an uncommitted write transaction — SQLite allows one
+        # writer at a time, so this INSERT would block for the full busy
+        # timeout while db_lock is held, freezing every endpoint.
         with db_lock:
             conn = db_handler.get_connection()
-            conn.execute("INSERT INTO system_logs (timestamp, level, message, related_id) VALUES (?, ?, ?, ?)",
-                         (datetime.now(), level, clean_msg, clean_id))
-            conn.commit()
-            conn.close()
-        print(f"[{level}] {message}") 
+            try:
+                conn.execute("INSERT INTO system_logs (timestamp, level, message, related_id) VALUES (?, ?, ?, ?)",
+                             (datetime.now(), level, clean_msg, clean_id))
+                conn.commit()
+            finally:
+                conn.close()
+        print(f"[{level}] {message}")
     except Exception as e:
         print(f"[!] Logging failed: {e}")
 
@@ -823,13 +829,28 @@ def _assemble_job(job_id):
 # HYBRID SCANNER (STREAMING GENERATOR)
 # ==============================================================================
 
-def scan_remote_http(url, prefix="", depth=0):
+# Only one scan may run at a time. Startup, the admin rescan button, and the
+# purge/archive actions all spawn scan threads — without this guard they used
+# to stack up and crawl the HTTP source several times concurrently.
+SCAN_LOCK = threading.Lock()
+
+def _legacy_encoded_id(job_id):
+    """The pre-fix scanner left subdirectory components percent-encoded.
+    Return that legacy form of a decoded job id (identical when no subdirs)."""
+    parts = job_id.split('/')
+    if len(parts) <= 1:
+        return job_id
+    return '/'.join(quote(p, safe='') for p in parts[:-1]) + '/' + parts[-1]
+
+def scan_remote_http(url, prefix="", depth=0, known_ids=None):
     """
     Recursively scans an HTTP directory listing for video files.
     YIELDS results as they are found (Generator) to allow real-time queuing.
+    Files whose job id is already in known_ids are skipped entirely, so a
+    rescan only fetches directory listings instead of re-HEADing every file.
     """
     if depth > 10: return # Prevent infinite recursion
-    
+
     headers = {'User-Agent': 'FractumManager/1.0'}
     
     # Retry Loop & Increased Timeout
@@ -867,18 +888,24 @@ def scan_remote_http(url, prefix="", depth=0):
                 # Without this, a percent-encoded subdir name (e.g. %C2%B7 for ·)
                 # gets double-encoded to %25C2%25B7, producing a 404.
                 from urllib.parse import unquote as _unquote
-                yield from scan_remote_http(full_url, prefix=f"{prefix}{_unquote(link)}", depth=depth+1)
+                yield from scan_remote_http(full_url, prefix=f"{prefix}{_unquote(link)}", depth=depth+1, known_ids=known_ids)
             elif any(link.lower().endswith(ext) for ext in VIDEO_EXTENSIONS):
                 from urllib.parse import unquote
                 clean_name = unquote(link)
                 clean_id = f"{prefix}{clean_name}"
-                
+
+                # Already tracked (under the current or legacy-encoded id)?
+                # Skip the per-file HEAD request — the dominant cost of a rescan.
+                if known_ids is not None and (clean_id in known_ids
+                                              or _legacy_encoded_id(clean_id) in known_ids):
+                    continue
+
                 size = 0
                 try:
                     h = requests.head(full_url, headers=headers, timeout=15)
                     size = int(h.headers.get('content-length', 0))
                 except: pass
-                
+
                 # Yield the found file immediately
                 yield (clean_id, clean_name, size)
                 
@@ -888,8 +915,17 @@ def scan_remote_http(url, prefix="", depth=0):
 def scan_and_queue():
     """
     Scans local and remote sources and updates the database/queue in batches.
+    Only one scan runs at a time; extra requests are dropped.
     """
-    
+    if not SCAN_LOCK.acquire(blocking=False):
+        print("[*] Scan already in progress — ignoring duplicate scan request.")
+        return
+    try:
+        _scan_and_queue_inner()
+    finally:
+        SCAN_LOCK.release()
+
+def _scan_and_queue_inner():
     # --- Helper: Process a batch of files ---
     def process_batch(file_batch):
         if not file_batch: return
@@ -924,14 +960,7 @@ def scan_and_queue():
                         # components are decoded, so the IDs differ even for the same
                         # file.  We normalise before inserting to avoid re-queuing
                         # files that are already done or in-progress.
-                        _id_parts = job_id.split('/')
-                        if len(_id_parts) > 1:
-                            _legacy_id = (
-                                '/'.join(quote(p, safe='') for p in _id_parts[:-1])
-                                + '/' + _id_parts[-1]
-                            )
-                        else:
-                            _legacy_id = job_id
+                        _legacy_id = _legacy_encoded_id(job_id)
                         if _legacy_id != job_id:
                             cursor.execute("SELECT id FROM jobs WHERE id=?", (_legacy_id,))
                             if cursor.fetchone():
@@ -969,9 +998,18 @@ def scan_and_queue():
     # --- 2. Scan Remote (Streaming) ---
     if REMOTE_SOURCE_URL:
         print(f"[*] Scanning REMOTE Source: {REMOTE_SOURCE_URL} ...")
+        # Snapshot the ids we already track so the crawl can skip the
+        # per-file HEAD request for every known file.
+        known_ids = set()
+        with db_lock:
+            conn = db_handler.get_connection()
+            try:
+                known_ids = {r[0] for r in conn.execute("SELECT id FROM jobs")}
+            finally:
+                conn.close()
         remote_batch = []
         # Iterate over the generator
-        for r_id, r_name, r_size in scan_remote_http(REMOTE_SOURCE_URL):
+        for r_id, r_name, r_size in scan_remote_http(REMOTE_SOURCE_URL, known_ids=known_ids):
             remote_batch.append((r_id, r_name, r_size, 'remote', REMOTE_SOURCE_URL))
             
             # Commit every 10 files so workers don't wait
@@ -1207,20 +1245,24 @@ def get_job():
     search_phases.append('local')
 
     try:
+        # Resolve series folders BEFORE taking db_lock: get_series_list reads
+        # the filesystem, and a slow/hung source mount must not stall every
+        # endpoint behind the lock.
+        search_attempts = [series_id] if series_id and series_id.isdigit() else []
+        search_attempts.append(None)
+        folder_filters = {sid: _resolve_folder_filter(sid) for sid in search_attempts}
+
         with db_lock:
             conn = db_handler.get_connection(); conn.row_factory = sqlite3.Row
             try:
                 c = conn.cursor()
                 job = None
-                
+
                 for source_type in search_phases:
                     if job: break
-                    
-                    search_attempts = [series_id] if series_id and series_id.isdigit() else []
-                    search_attempts.append(None) 
-                    
+
                     for current_search_id in search_attempts:
-                        folder_filter = _resolve_folder_filter(current_search_id)
+                        folder_filter = folder_filters.get(current_search_id)
 
                         params = [source_type]
                         query_parts = ["status='queued'", "source_type=?", "COALESCE(fail_count,0) < 5"]
@@ -1239,27 +1281,37 @@ def get_job():
                 
                 if job:
                     job['download_url'] = build_download_url(job['id'], job['source_type'], job.get('source_url'))
-                    if job['source_type'] != 'remote':
-                         # Lazily compute source hash for local files on first pickup
-                         if not job.get('source_hash'):
-                             _src_path = os.path.join(SOURCE_DIRECTORY, job['id'].replace('/', os.sep))
-                             _computed = _fast_hash_file(_src_path)
-                             if _computed:
-                                 conn.execute("UPDATE jobs SET source_hash=? WHERE id=?",
-                                              (_computed, job['id']))
-                                 job['source_hash'] = _computed
-
-                    # Never reveal the hash to the worker — workers must submit their own
-                    # computed hash blind so they cannot cheat by echoing the known value.
-                    job.pop('source_hash', None)
-
-                    conn.execute("UPDATE jobs SET status='processing', worker_id=?, worker_version=?, last_updated=?, started_at=? WHERE id=?", 
+                    conn.execute("UPDATE jobs SET status='processing', worker_id=?, worker_version=?, last_updated=?, started_at=? WHERE id=?",
                         (worker_id, worker_version, datetime.now(), datetime.now(), job['id']))
                     conn.commit()
-                    return jsonify({"status": "ok", "job": job})
             finally:
                 conn.close()
+
+        if job is None:
             return jsonify({"status": "empty"})
+
+        # Lazily compute the source hash for local files on first pickup —
+        # OUTSIDE db_lock, since it reads 4 MB from the source disk and a slow
+        # drive/mount would otherwise stall every endpoint. If the worker's
+        # hash check races this, /verify_source_hash just answers "pending".
+        needs_hash = (job['source_type'] != 'remote' and not job.get('source_hash'))
+        # Never reveal the hash to the worker — workers must submit their own
+        # computed hash blind so they cannot cheat by echoing the known value.
+        job.pop('source_hash', None)
+        if needs_hash:
+            _src_path = os.path.join(SOURCE_DIRECTORY, job['id'].replace('/', os.sep))
+            _computed = _fast_hash_file(_src_path)
+            if _computed:
+                with db_lock:
+                    conn = db_handler.get_connection()
+                    try:
+                        conn.execute("UPDATE jobs SET source_hash=? WHERE id=? AND source_hash IS NULL",
+                                     (_computed, job['id']))
+                        conn.commit()
+                    finally:
+                        conn.close()
+
+        return jsonify({"status": "ok", "job": job})
     except Exception as e:
         log_event("ERROR", f"get_job failed: {e}")
         return jsonify({"status": "error"}), 500
@@ -1862,7 +1914,8 @@ def get_logs():
 def admin_action():
     data = request.json or {}; job_id = data.get('job_id'); action = data.get('action')
     log_event("WARN", f"Admin performed '{action}' on job", job_id)
-    
+    post_commit_logs = []
+
     with db_lock:
         conn = db_handler.get_connection(); c = conn.cursor()
         try:
@@ -1900,18 +1953,24 @@ def admin_action():
                     c.execute("UPDATE jobs SET id = ? WHERE id = ?", (new_id, jid))
                     # Keep chunk rows pointing at the archived job so scoreboard credit survives
                     c.execute("UPDATE chunks SET job_id = ? WHERE job_id = ?", (new_id, jid))
-                log_event("WARN", f"Admin archived {len(rows)} jobs.")
+                post_commit_logs.append(f"Admin archived {len(rows)} jobs.")
             elif action == 'purge_queue':
                 c.execute("DELETE FROM jobs WHERE status='queued'")
-                log_event("WARN", "Admin PURGED the queue. Rescan triggered (background).")
+                post_commit_logs.append("Admin PURGED the queue. Rescan triggered (background).")
             elif action == 'clear_error_reports':
                 c.execute("DELETE FROM error_reports")
-                log_event("WARN", "Admin cleared all error reports.")
+                post_commit_logs.append("Admin cleared all error reports.")
 
             conn.commit()
         finally:
             conn.close()
-            
+
+    # log_event opens its own write connection — calling it while the
+    # transaction above was still open used to block it for the full SQLite
+    # busy timeout (60s) WITH db_lock held, freezing every worker endpoint.
+    for _msg in post_commit_logs:
+        log_event("WARN", _msg)
+
     if action == 'purge_queue' or action == 'archive_history':
         # FIXED: Run scan in a background thread to prevent client timeout
         threading.Thread(target=scan_and_queue, daemon=True).start()

--- a/manager.py
+++ b/manager.py
@@ -116,6 +116,7 @@ CHUNK_STALE_SECONDS = 1800                          # processing chunk with no h
 CHUNK_MAX_FAILS = 3                                 # chunk failures before whole-job fallback
 ASSEMBLING_JOBS = set()                             # job_ids with an assembly thread running
 ASSEMBLY_LOCK = threading.Lock()
+SPLIT_LOCK = threading.Lock()                       # at most one probe/split at a time
 
 # Cache for outdated worker logs to prevent spamming DB
 OUTDATED_LOG_CACHE = {} 
@@ -352,25 +353,34 @@ def _parse_rate(rate_str):
     except (ValueError, ZeroDivisionError):
         return 0.0
 
-def _probe_media(src):
+def _probe_media(src, timeout=60):
     """ffprobe a local path or URL. Returns a dict with duration/stream layout,
     or None on failure."""
     try:
         cmd = ['ffprobe', '-v', 'error', '-print_format', 'json',
                '-show_streams', '-show_format', src]
-        res = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         if res.returncode != 0:
             return None
         data = json.loads(res.stdout)
         dur = float(data.get('format', {}).get('duration') or 0)
         if dur <= 0:
             return None
+        try:
+            format_start = float(data.get('format', {}).get('start_time') or 0)
+        except (TypeError, ValueError):
+            format_start = 0.0
         streams = data.get('streams', [])
         has_audio = any(s.get('codec_type') == 'audio' for s in streams)
         sub_codecs = ['subrip', 'ass', 'webvtt', 'mov_text', 'text', 'srt', 'ssa']
         has_subs = any(s.get('codec_type') == 'subtitle'
                        and s.get('codec_name', '').lower() in sub_codecs
                        for s in streams)
+        audio_start = None
+        first_audio = next((s for s in streams if s.get('codec_type') == 'audio'), None)
+        if first_audio is not None:
+            try: audio_start = float(first_audio.get('start_time') or 0)
+            except (TypeError, ValueError): audio_start = None
 
         # Frame-rate info of the first video stream — chunk boundaries must be
         # snapped to the frame grid, which is only well-defined for CFR sources.
@@ -387,6 +397,7 @@ def _probe_media(src):
         return {
             "duration": dur, "has_audio": has_audio, "has_subs": has_subs,
             "fps": fps, "start_time": start_time, "cfr": is_cfr,
+            "format_start": format_start, "audio_start": audio_start,
         }
     except Exception:
         return None
@@ -428,28 +439,35 @@ def _resolve_folder_filter(series_id):
             return s['folder']
     return None
 
-def _requeue_job_whole(conn, job_id, reason):
-    """Chunking gave up on this job: drop chunk state and requeue it for
-    classic whole-file encoding (chunkable=0 so it is never split again)."""
+def _remove_chunk_dir_async(job_id):
+    """Delete a job's chunk files off-thread — chunk dirs can hold gigabytes
+    and callers usually hold db_lock."""
+    threading.Thread(target=shutil.rmtree, args=(_chunk_dir(job_id),),
+                     kwargs={'ignore_errors': True}, daemon=True).start()
+
+def _requeue_job_whole(conn, job_id, reason, penalize=True, disable_chunking=True):
+    """Chunking gave up on this job: drop chunk state and put it back in the queue.
+
+    penalize:        count this as a failure (encode/verify problems). Off for
+                     no-fault paths like 'no workers were online'.
+    disable_chunking: set chunkable=0 so the job is encoded whole next time.
+                     Off when chunking itself wasn't at fault."""
     c = conn.cursor()
     c.execute("SELECT COALESCE(fail_count, 0) FROM jobs WHERE id=?", (job_id,))
     row = c.fetchone()
     if row is None:
         return
-    new_fc = row[0] + 1
+    new_fc = row[0] + (1 if penalize else 0)
     new_status = 'permanently_failed' if new_fc >= 5 else 'queued'
     c.execute("DELETE FROM chunks WHERE job_id=?", (job_id,))
-    c.execute("UPDATE jobs SET status=?, chunked=0, chunkable=0, progress=0, worker_id=NULL, "
+    c.execute("UPDATE jobs SET status=?, chunked=0, chunkable=?, progress=0, worker_id=NULL, "
               "started_at=NULL, fail_count=?, last_updated=? WHERE id=?",
-              (new_status, new_fc, datetime.now(), job_id))
+              (new_status, 0 if disable_chunking else None, new_fc, datetime.now(), job_id))
     # Commit before log_event opens its own write connection, otherwise the
     # pending transaction on `conn` would block it (SQLite single-writer).
     conn.commit()
-    try:
-        shutil.rmtree(_chunk_dir(job_id), ignore_errors=True)
-    except Exception:
-        pass
-    log_event("WARN", f"Chunked encode abandoned ({reason}). Job requeued as whole-file (status={new_status}).", job_id)
+    _remove_chunk_dir_async(job_id)
+    log_event("WARN", f"Chunked encode abandoned ({reason}). Job requeued (status={new_status}).", job_id)
 
 def _update_job_chunk_progress(conn, job_id):
     """Recompute aggregate job progress from its chunks (call with db_lock held)."""
@@ -536,10 +554,21 @@ def _split_claimed_job(job):
     else:
         src = os.path.join(SOURCE_DIRECTORY, job_id.replace('/', os.sep))
 
-    probe = _probe_media(src) if src else None
+    # Probe with a short timeout: this runs inside a /get_chunk request and
+    # workers give up waiting after ~30s.
+    probe = _probe_media(src, timeout=20) if src else None
     ranges = None
     if probe and probe['cfr']:
-        ranges = _plan_chunks(probe['duration'], probe['fps'], probe['start_time'])
+        # Streams that don't share a common start offset (e.g. broadcast
+        # captures where audio leads video) can't be sliced on the video
+        # frame grid without shifting A/V sync — encode those whole.
+        skew = abs(probe['start_time'] - probe['format_start'])
+        if probe['audio_start'] is not None:
+            skew = max(skew, abs(probe['audio_start'] - probe['start_time']))
+        if skew > 0.15:
+            log_event("INFO", f"Stream start offsets differ by {skew:.2f}s — encoding whole.", job_id)
+        else:
+            ranges = _plan_chunks(probe['duration'], probe['fps'], probe['start_time'])
     elif probe:
         log_event("INFO", "Source is VFR / has no reliable frame grid — encoding whole.", job_id)
 
@@ -548,30 +577,40 @@ def _split_claimed_job(job):
         try:
             c = conn.cursor()
             if not ranges:
-                # Too short / VFR / unprobeable: hand it back for whole-file encoding
+                # Too short / VFR / unprobeable: hand it back for whole-file
+                # encoding. Guarded so we don't clobber the job if an admin
+                # reset it (and a worker re-claimed it) while we were probing.
                 c.execute("UPDATE jobs SET status='queued', worker_id=NULL, started_at=NULL, "
-                          "chunkable=0, source_duration_sec=?, last_updated=? WHERE id=?",
+                          "chunkable=0, source_duration_sec=?, last_updated=? "
+                          "WHERE id=? AND status='processing' AND worker_id='(chunking)'",
                           (probe['duration'] if probe else None, datetime.now(), job_id))
                 conn.commit()
                 return False
 
             duration, has_audio, has_subs = probe['duration'], probe['has_audio'], probe['has_subs']
             now = datetime.now()
+            total = len(ranges) + (1 if (has_audio or has_subs) else 0)
+            # Re-assert our claim before creating chunks: an admin reset (or a
+            # whole-file worker via /get_job after such a reset) may have taken
+            # the job while the probe ran. If the claim is gone, walk away.
+            c.execute("UPDATE jobs SET chunked=1, chunkable=1, source_duration_sec=?, total_chunks=?, "
+                      "progress=0, worker_id='(chunked)', last_updated=? "
+                      "WHERE id=? AND status='processing' AND worker_id='(chunking)'",
+                      (duration, total, now, job_id))
+            if c.rowcount != 1:
+                conn.commit()
+                log_event("WARN", "Split abandoned: job was taken by someone else during the probe.", job_id)
+                return False
             # Stale rows can exist if this job was reset earlier — start clean
             c.execute("DELETE FROM chunks WHERE job_id=?", (job_id,))
             for i, (start, dur) in enumerate(ranges):
                 c.execute("INSERT INTO chunks (job_id, kind, chunk_index, start_sec, duration_sec, "
                           "status, last_updated) VALUES (?, 'video', ?, ?, ?, 'pending', ?)",
                           (job_id, i, start, dur, now))
-            total = len(ranges)
             if has_audio or has_subs:
                 c.execute("INSERT INTO chunks (job_id, kind, chunk_index, start_sec, duration_sec, "
                           "status, last_updated) VALUES (?, 'audio', -1, 0, ?, 'pending', ?)",
                           (job_id, duration, now))
-                total += 1
-            c.execute("UPDATE jobs SET chunked=1, chunkable=1, source_duration_sec=?, total_chunks=?, "
-                      "progress=0, worker_id='(chunked)', last_updated=? WHERE id=?",
-                      (duration, total, now, job_id))
             conn.commit()
             log_event("INFO", f"Split into {total} chunk(s) ({duration/60:.1f} min source).", job_id)
             return True
@@ -597,8 +636,7 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb):
                 params.append(int(max_size_mb) * 1024 * 1024)
             sql = ("SELECT c.rowid AS chunk_rowid, c.job_id, c.kind, c.chunk_index, c.start_sec, c.duration_sec, "
                    "j.filename, j.file_size, j.source_type, j.source_url, j.content_profile, "
-                   "j.source_duration_sec, j.total_chunks, "
-                   "(SELECT MAX(c2.chunk_index) FROM chunks c2 WHERE c2.job_id = c.job_id AND c2.kind='video') AS max_video_index "
+                   "j.source_duration_sec, j.total_chunks "
                    "FROM chunks c JOIN jobs j ON j.id = c.job_id "
                    f"WHERE {' AND '.join(query_parts)} "
                    "ORDER BY j.started_at ASC, CASE WHEN c.kind='audio' THEN 0 ELSE 1 END, c.chunk_index ASC "
@@ -609,9 +647,14 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb):
             if row is None:
                 return None
             chunk = dict(row)
-            # The final video chunk encodes to EOF instead of using -t
-            max_video_index = chunk.pop('max_video_index')
-            chunk['is_last'] = bool(chunk['kind'] == 'video' and chunk['chunk_index'] == max_video_index)
+            # The final video chunk encodes to EOF instead of using -t.
+            # Computed as a separate single-row query so the assignment scan
+            # doesn't pay a correlated subquery per candidate row.
+            chunk['is_last'] = False
+            if chunk['kind'] == 'video':
+                c.execute("SELECT COALESCE(MAX(chunk_index), -1) FROM chunks WHERE job_id=? AND kind='video'",
+                          (chunk['job_id'],))
+                chunk['is_last'] = (chunk['chunk_index'] == c.fetchone()[0])
             now = datetime.now()
             c.execute("UPDATE chunks SET status='processing', worker_id=?, progress=0, last_updated=? "
                       "WHERE rowid=?", (worker_id, now, chunk.pop('chunk_rowid')))
@@ -652,6 +695,13 @@ def _verify_chunk(filepath, kind, expected_dur, is_last):
             for s in audio:
                 if s.get('codec_name') != 'opus':
                     return False, "Invalid Audio Codec"
+            # A truncated audio track must not slip into the final mux.
+            # (Duration is only meaningful when an audio stream exists —
+            # subtitle-only files end at the last cue.)
+            if audio and expected_dur > 0:
+                tolerance = max(10.0, expected_dur * 0.05)
+                if abs(dur - expected_dur) > tolerance:
+                    return False, f"Audio duration mismatch ({dur:.1f}s vs expected {expected_dur:.1f}s)"
         return True, "Verified"
     except Exception as e:
         return False, str(e)
@@ -1170,12 +1220,8 @@ def get_job():
                     search_attempts.append(None) 
                     
                     for current_search_id in search_attempts:
-                        folder_filter = None
-                        if current_search_id:
-                            for s in get_series_list()[0]:
-                                if s['id'] == int(current_search_id):
-                                    folder_filter = s['folder']; break
-                        
+                        folder_filter = _resolve_folder_filter(current_search_id)
+
                         params = [source_type]
                         query_parts = ["status='queued'", "source_type=?", "COALESCE(fail_count,0) < 5"]
                         
@@ -1192,16 +1238,8 @@ def get_job():
                         if row: job = dict(row); break
                 
                 if job:
-                    if job['source_type'] == 'remote':
-                        # Use stored URL if available, else fallback
-                        base_url = job.get('source_url') if job.get('source_url') else REMOTE_SOURCE_URL
-                        if base_url:
-                            job['download_url'] = urljoin(base_url, quote(job['id']))
-                        else:
-                             # Fallback for old remote jobs if config is gone (might fail, but best effort)
-                             job['download_url'] = "" 
-                    else:
-                         job['download_url'] = f"{SERVER_URL_DISPLAY.rstrip('/')}/download_source/{quote(job['id'], safe='/')}"
+                    job['download_url'] = build_download_url(job['id'], job['source_type'], job.get('source_url'))
+                    if job['source_type'] != 'remote':
                          # Lazily compute source hash for local files on first pickup
                          if not job.get('source_hash'):
                              _src_path = os.path.join(SOURCE_DIRECTORY, job['id'].replace('/', os.sep))
@@ -1249,16 +1287,19 @@ def get_chunk():
         folder_filter = _resolve_folder_filter(series_id)
 
         chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb)
-        if chunk is None:
+        if chunk is None and SPLIT_LOCK.acquire(blocking=False):
             # No pending chunks anywhere — split the next queued job.
-            # Try a few candidates since some may turn out too short to split.
-            for _ in range(3):
+            # One candidate per request and one split at a time: this keeps
+            # the request latency bounded (workers time out around 30s) and
+            # stops a poll storm from splitting many jobs simultaneously.
+            # An unsplittable candidate is requeued with chunkable=0 and gets
+            # picked up whole via /get_job instead.
+            try:
                 job = _claim_job_for_split(folder_filter, max_size_mb)
-                if job is None:
-                    break
-                if _split_claimed_job(job):
+                if job is not None and _split_claimed_job(job):
                     chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb)
-                    break
+            finally:
+                SPLIT_LOCK.release()
 
         if chunk is None:
             return jsonify({"status": "empty"})
@@ -1291,8 +1332,10 @@ def upload_chunk():
             c.execute("SELECT status, duration_sec FROM chunks WHERE job_id=? AND kind=? AND chunk_index=?",
                       (job_id, kind, chunk_index))
             crow = c.fetchone()
-            c.execute("SELECT COALESCE(total_chunks,0) as total_chunks, status FROM jobs WHERE id=?", (job_id,))
+            c.execute("SELECT status FROM jobs WHERE id=?", (job_id,))
             jrow = c.fetchone()
+            c.execute("SELECT COALESCE(MAX(chunk_index), -1) FROM chunks WHERE job_id=? AND kind='video'", (job_id,))
+            max_video_index = c.fetchone()[0]
         finally:
             conn.close()
 
@@ -1306,9 +1349,8 @@ def upload_chunk():
     temp_path = os.path.join(quarantine_dir, f"{uuid.uuid4().hex}.mp4")
     request.files['file'].save(temp_path)
 
-    # The highest-indexed video chunk runs to EOF, so its duration is fuzzier
-    n_video = jrow['total_chunks']
-    is_last = (kind == 'video' and chunk_index >= n_video - 2)
+    # Only the highest-indexed video chunk runs to EOF, so only its duration is fuzzier
+    is_last = (kind == 'video' and chunk_index == max_video_index)
     is_valid, reason = _verify_chunk(temp_path, kind, float(crow['duration_sec'] or 0), is_last)
     if not is_valid:
         try: os.remove(temp_path)
@@ -1376,9 +1418,12 @@ def report_chunk():
                     progress = max(0, min(100, int(d.get('progress', 0))))
                 except (TypeError, ValueError):
                     progress = 0
-                c.execute("UPDATE chunks SET progress=?, last_updated=?, worker_id=? "
-                          "WHERE job_id=? AND kind=? AND chunk_index=? AND status='processing'",
-                          (progress, datetime.now(), worker_id, job_id, kind, chunk_index))
+                # Ownership guard: a worker whose chunk timed out and was
+                # reassigned must not steal it back via a late heartbeat.
+                c.execute("UPDATE chunks SET progress=?, last_updated=? "
+                          "WHERE job_id=? AND kind=? AND chunk_index=? AND status='processing' "
+                          "AND (worker_id IS NULL OR worker_id=?)",
+                          (progress, datetime.now(), job_id, kind, chunk_index, worker_id))
             _update_job_chunk_progress(conn, job_id)
             conn.commit()
         finally:
@@ -1496,7 +1541,14 @@ def receive_log():
             log_event("WARN", f"CHEATING DETECTED by {worker_id}: {warning_str}", parent_job_id)
             with db_lock:
                 conn = db_handler.get_connection()
-                conn.execute("UPDATE jobs SET warnings=? WHERE id=?", (warning_str, parent_job_id))
+                if is_chunk_log:
+                    # A chunked job produces one log per chunk — append so no
+                    # worker's cheat evidence (or the assembly drift warning)
+                    # is overwritten by a later log.
+                    conn.execute("UPDATE jobs SET warnings = COALESCE(warnings || ' | ', '') || ? WHERE id=?",
+                                 (warning_str, parent_job_id))
+                else:
+                    conn.execute("UPDATE jobs SET warnings=? WHERE id=?", (warning_str, parent_job_id))
                 conn.commit()
                 conn.close()
                 
@@ -1685,16 +1737,19 @@ def report_status():
     with db_lock:
         conn = db_handler.get_connection()
         try:
-            sql = "UPDATE jobs SET status=?, worker_id=?, progress=?, last_updated=? WHERE id=?"
+            # COALESCE(chunked,0)=0 guard: a whole-file worker whose timed-out
+            # job was since split into chunks must not clobber the chunked
+            # job's status/worker (that would stall assignment and assembly).
+            sql = "UPDATE jobs SET status=?, worker_id=?, progress=?, last_updated=? WHERE id=? AND COALESCE(chunked, 0)=0"
             params = [status, worker_id, d.get('progress',0), datetime.now(), d.get('job_id')]
-            if d.get('duration', 0) > 0: 
-                sql = "UPDATE jobs SET status=?, worker_id=?, progress=?, last_updated=?, duration=? WHERE id=?"
+            if d.get('duration', 0) > 0:
+                sql = "UPDATE jobs SET status=?, worker_id=?, progress=?, last_updated=?, duration=? WHERE id=? AND COALESCE(chunked, 0)=0"
                 params.insert(4, d.get('duration'))
             conn.execute(sql, tuple(params))
             if status == 'failed':
                 job_id_val = d.get('job_id')
-                conn.execute("UPDATE jobs SET fail_count = COALESCE(fail_count, 0) + 1 WHERE id=?", (job_id_val,))
-                conn.execute("UPDATE jobs SET status='permanently_failed' WHERE id=? AND COALESCE(fail_count, 0) >= 5", (job_id_val,))
+                conn.execute("UPDATE jobs SET fail_count = COALESCE(fail_count, 0) + 1 WHERE id=? AND COALESCE(chunked, 0)=0", (job_id_val,))
+                conn.execute("UPDATE jobs SET status='permanently_failed' WHERE id=? AND COALESCE(fail_count, 0) >= 5 AND COALESCE(chunked, 0)=0", (job_id_val,))
             conn.commit()
         finally:
             conn.close()
@@ -1711,6 +1766,9 @@ def api_stats():
             c = conn.cursor()
             # Scoreboard: whole-file jobs credit their single worker; chunked jobs
             # credit each contributor with the minutes of source they encoded.
+            # Chunk credit counts only video chunks (the audio pass spans the
+            # whole file and would double the job's minutes) and only jobs
+            # that actually completed.
             c.execute(f"""
                 SELECT worker_id, SUM(total_minutes) as total_minutes, SUM(files_count) as files_count FROM (
                     SELECT CASE WHEN instr(worker_id, '-') > 0 THEN substr(worker_id, 1, instr(worker_id, '-') - 1) ELSE worker_id END as worker_id,
@@ -1720,7 +1778,8 @@ def api_stats():
                     UNION ALL
                     SELECT CASE WHEN instr(worker_id, '-') > 0 THEN substr(worker_id, 1, instr(worker_id, '-') - 1) ELSE worker_id END as worker_id,
                            CAST(SUM(duration_sec) / 60.0 AS INTEGER) as total_minutes, COUNT(DISTINCT job_id) as files_count
-                    FROM chunks WHERE status='completed' AND worker_id IS NOT NULL {time_filter}
+                    FROM chunks WHERE status='completed' AND worker_id IS NOT NULL AND kind='video'
+                          AND EXISTS (SELECT 1 FROM jobs j2 WHERE j2.id = chunks.job_id AND j2.status='completed') {time_filter}
                     GROUP BY 1
                 ) GROUP BY worker_id ORDER BY total_minutes DESC""")
             sb = [dict(r) for r in c.fetchall()]
@@ -1728,14 +1787,19 @@ def api_stats():
             c.execute("SELECT id, COALESCE(worker_id, 'Pending...') as worker_id, filename, duration, progress, status, COALESCE(chunked, 0) as chunked FROM jobs WHERE status IN ('processing', 'downloading', 'uploading')")
             act = [dict(r) for r in c.fetchall()]
 
-            # For chunked jobs, show swarm status instead of a single worker name
+            # For chunked jobs, show swarm status instead of a single worker
+            # name. Scoped to the active jobs — the chunks table keeps
+            # historical rows for the scoreboard and grows over time.
             chunk_info = {}
-            c.execute("""SELECT job_id, COUNT(*) as total,
-                                SUM(CASE WHEN status='completed' THEN 1 ELSE 0 END) as done,
-                                COUNT(DISTINCT CASE WHEN status='processing' THEN worker_id END) as active_workers
-                         FROM chunks GROUP BY job_id""")
-            for r in c.fetchall():
-                chunk_info[r['job_id']] = dict(r)
+            active_chunked_ids = [a['id'] for a in act if a['chunked']]
+            if active_chunked_ids:
+                ph = ",".join("?" * len(active_chunked_ids))
+                c.execute(f"""SELECT job_id, COUNT(*) as total,
+                                    SUM(CASE WHEN status='completed' THEN 1 ELSE 0 END) as done,
+                                    COUNT(DISTINCT CASE WHEN status='processing' THEN worker_id END) as active_workers
+                             FROM chunks WHERE job_id IN ({ph}) GROUP BY job_id""", active_chunked_ids)
+                for r in c.fetchall():
+                    chunk_info[r['job_id']] = dict(r)
             for a in act:
                 ci = chunk_info.get(a['id'])
                 if a['chunked'] and ci:
@@ -1805,22 +1869,28 @@ def admin_action():
             if action == 'delete':
                 c.execute("DELETE FROM jobs WHERE id = ?", (job_id,))
                 c.execute("DELETE FROM chunks WHERE job_id = ?", (job_id,))
-                shutil.rmtree(_chunk_dir(job_id), ignore_errors=True)
+                _remove_chunk_dir_async(job_id)
             elif action == 'retry':
                 c.execute("DELETE FROM chunks WHERE job_id = ?", (job_id,))
-                shutil.rmtree(_chunk_dir(job_id), ignore_errors=True)
+                _remove_chunk_dir_async(job_id)
                 c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, fail_count=0, chunked=0, chunkable=NULL, started_at=NULL, last_updated=? WHERE id=?", (datetime.now(), job_id))
             elif action == 'retry_all_failed':
                 c.execute("SELECT id FROM jobs WHERE status IN ('failed', 'permanently_failed')")
                 for (fid,) in c.fetchall():
-                    shutil.rmtree(_chunk_dir(fid), ignore_errors=True)
+                    _remove_chunk_dir_async(fid)
                 c.execute("DELETE FROM chunks WHERE job_id IN (SELECT id FROM jobs WHERE status IN ('failed', 'permanently_failed'))")
                 c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, fail_count=0, chunked=0, chunkable=NULL, started_at=NULL, last_updated=? WHERE status IN ('failed', 'permanently_failed')", (datetime.now(),))
             elif action == 'clear_stale':
                 cutoff = datetime.now() - timedelta(minutes=10)
-                # Chunked jobs are excluded: their liveness is tracked per-chunk by the maintenance loop
                 c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, last_updated=?, started_at=NULL WHERE status IN ('processing', 'downloading', 'uploading') AND COALESCE(chunked, 0)=0 AND last_updated < ?", (datetime.now(), cutoff))
                 c.execute("UPDATE chunks SET status='pending', worker_id=NULL, progress=0, last_updated=? WHERE status='processing' AND last_updated < ?", (datetime.now(), cutoff))
+                # A chunked job whose chunks have ALL gone silent is wedged
+                # (e.g. no chunk-capable workers left) — give the admin the
+                # same recovery lever whole-file jobs have. No fail penalty.
+                c.execute("SELECT id FROM jobs WHERE status='processing' AND COALESCE(chunked, 0)=1 AND last_updated < ?", (cutoff,))
+                for (wjid,) in c.fetchall():
+                    _requeue_job_whole(conn, wjid, "admin clear_stale",
+                                       penalize=False, disable_chunking=False)
             elif action == 'archive_history':
                 ts = int(time.time())
                 c.execute("SELECT id FROM jobs WHERE status='completed' AND id NOT LIKE 'HISTORY_%'")
@@ -1937,11 +2007,14 @@ def maintenance_loop():
                                         AND NOT EXISTS (SELECT 1 FROM chunks c WHERE c.job_id = j.id AND c.status != 'completed')""")
                     assembly_candidates = [r[0] for r in cursor.fetchall()]
 
-                    # Backstop: a chunked job with zero activity for 24h gets requeued whole
-                    dead_cutoff = now - timedelta(hours=24)
+                    # Backstop: a chunked job with zero chunk activity for 6h gets
+                    # requeued (e.g. every chunk-capable worker left). No fail
+                    # penalty and chunking stays allowed — nothing actually failed.
+                    dead_cutoff = now - timedelta(hours=6)
                     cursor.execute("SELECT id FROM jobs WHERE COALESCE(chunked, 0)=1 AND status='processing' AND last_updated < ?", (dead_cutoff,))
                     for (jid,) in cursor.fetchall():
-                        _requeue_job_whole(conn, jid, "no chunk activity for 24h")
+                        _requeue_job_whole(conn, jid, "no chunk activity for 6h",
+                                           penalize=False, disable_chunking=False)
                     conn.commit()
                 finally:
                     conn.close()

--- a/reset_series.py
+++ b/reset_series.py
@@ -42,16 +42,32 @@ def reset_series(search_term):
             return
 
         print(f"[*] Found {count} jobs. Resetting them to 'queued'...")
-        
+
         # Update status to 'queued' so workers pick them up again.
         # We also clear worker_id, progress, duration, and timestamps to ensure a clean start.
-        c.execute("""
-            UPDATE jobs 
-            SET status='queued', progress=0, worker_id=NULL, 
-                last_updated=?, duration=0, started_at=NULL
-            WHERE id LIKE ?
-        """, (datetime.now(), pattern))
-        
+        # Chunk state (chunked encoding) is cleared too, mirroring the admin
+        # 'retry' action — otherwise stale chunk rows could be assembled into
+        # a re-queued job or leave it invisible to the stale-job timeout.
+        try:
+            c.execute("DELETE FROM chunks WHERE job_id LIKE ?", (pattern,))
+        except sqlite3.OperationalError:
+            pass  # pre-chunking database: no chunks table yet
+        try:
+            c.execute("""
+                UPDATE jobs
+                SET status='queued', progress=0, worker_id=NULL,
+                    last_updated=?, duration=0, started_at=NULL,
+                    chunked=0, chunkable=NULL
+                WHERE id LIKE ?
+            """, (datetime.now(), pattern))
+        except sqlite3.OperationalError:
+            c.execute("""
+                UPDATE jobs
+                SET status='queued', progress=0, worker_id=NULL,
+                    last_updated=?, duration=0, started_at=NULL
+                WHERE id LIKE ?
+            """, (datetime.now(), pattern))
+
         conn.commit()
         conn.close()
         print(f"[+] Success! {count} jobs have been reset and added back to the queue.")

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -343,7 +343,12 @@
                 if (!res.ok) throw new Error("API Offline");
                 const rawData = await res.json();
                 
-                const completed = rawData.scoreboard.reduce((acc, u) => acc + u.files_count, 0);
+                // Prefer the true completed-jobs count: with chunked encoding a
+                // single video contributes to several workers' files_count, so
+                // summing the scoreboard would overcount.
+                const completed = (rawData.total_completed !== undefined)
+                    ? rawData.total_completed
+                    : rawData.scoreboard.reduce((acc, u) => acc + u.files_count, 0);
                 const activeCount = rawData.active.length;
                 
                 const data = {

--- a/worker_template.py
+++ b/worker_template.py
@@ -113,7 +113,7 @@ except ImportError as _e:
 DEFAULT_MANAGER_URL = "https://encode.fractumseraph.net/"
 DEFAULT_USERNAME = "Anonymous"
 DEFAULT_WORKERNAME = f"Node-{int(time.time())}"
-WORKER_VERSION = "3.1.0"
+WORKER_VERSION = "3.1.1"
 WORKER_SECRET = os.environ.get("WORKER_SECRET", "DefaultInsecureSecret")
 
 SHUTDOWN_EVENT = threading.Event()
@@ -1985,6 +1985,11 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                         if cdata.get("status") == "ok" and cdata.get("chunk"):
                             process_chunk(cdata["chunk"])
                             continue
+                        elif cdata.get("message") == "Chunking disabled":
+                            # Config toggle is static per manager process — stop
+                            # doubling every idle poll with a pointless request.
+                            _CHUNK_SUPPORT["ok"] = False
+                            log(worker_id, "Chunked encoding disabled on manager — using whole-file mode.")
                 except Exception:
                     pass  # chunk fetch failed — fall through to /get_job
 


### PR DESCRIPTION
## Summary

Follow-up to #10 (merged): an 8-angle adversarial code review of the chunked-encoding feature surfaced several real defects and rough edges. This PR fixes all of them. Encoding targets remain untouched, and all changes stay queue-safe for a running instance (no schema changes at all this time — only logic).

## Correctness fixes

- **Truncated chunks could slip into the final file**: `upload_chunk` derived "is this the last video chunk" from `total_chunks`, which includes the audio chunk — for sources *without* an audio track, the second-to-last chunk was also verified with the loose run-to-EOF tolerance (10% instead of 5%). Now derived exactly from `MAX(chunk_index)`.
- **Audio chunk duration was never verified** — a truncated audio track (encoder died early but exited 0) would be muxed into the published file with no warning. Now rejected on upload.
- **Heartbeat ownership steal**: a worker whose stale chunk had been reassigned could re-claim it with a late heartbeat, which then made the real owner's failure reports be silently ignored. Heartbeats no longer change the assignee.
- **A/V start-offset sources** (e.g. broadcast captures where audio leads video): slicing these on the video frame grid could shift lip-sync. Sources whose stream start offsets differ by >0.15s are now encoded whole.
- **Split race**: an admin reset (or `clear_stale`) during the probe window could let the same video be encoded whole *and* chunked simultaneously. The split now re-asserts its claim atomically before creating chunks.
- **`report_status` clobber**: a timed-out whole-file worker resurfacing could overwrite the status of a job the swarm had since split, stalling assignment and assembly. Chunked jobs are now ignored by that endpoint.
- **`reset_series.py`** now clears chunk state like the admin retry action (with graceful fallback on pre-chunking databases).
- **Warnings audit trail**: chunk-log cheat warnings now append instead of overwriting, so one worker's GPU/preset evidence can't be erased by a later chunk's log.

## Resilience / efficiency

- The no-chunk-activity backstop drops from 24h to **6h**, no longer increments `fail_count`, and no longer disables chunking — a weekend swarm outage can't march healthy jobs toward `permanently_failed`. The admin **Prune Dead Workers** action can now also rescue a wedged chunked job.
- Splitting is serialized: one probe at a time, one candidate per request, 20s probe timeout — a poll storm can't split many jobs at once or exceed the worker's request timeout.
- Chunk-directory deletion moved off-thread (was running under the global DB lock; chunk dirs can hold gigabytes).
- `api_stats` scopes chunk aggregation to active jobs (the chunks table grows over time) and the scoreboard now credits only **video**-chunk minutes of **completed** jobs — previously the audio pass double-counted the full source duration and in-flight jobs earned premature credit. The dashboard "Completed" tile uses the true completed count instead of summing per-worker contributions.
- `get_job` now shares `build_download_url` / `_resolve_folder_filter` with the chunk path instead of keeping inline copies that could drift.
- Workers stop polling `/get_chunk` when the manager reports chunking disabled (halves idle polling traffic in that configuration). Worker version 3.1.1 so fleets pick this up automatically.

## Testing

- Full E2E re-run on a live manager + 3-thread worker: split → parallel encode → upload verification → lossless assembly; output still frame-exact (1500/1500 frames, 150.02s, AV1/Opus/mov_text all present) and the scoreboard now shows video-only minutes.
- `py_compile` clean on `manager.py`, `worker_template.py`, `reset_series.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_