### PR TITLE
Fix non-ASCII filenames breaking remote jobs (BURN·E.2008)

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -12,6 +12,7 @@ import secrets
 import platform
 import gzip
 import hashlib
+import html as html_lib
 from functools import wraps
 from datetime import datetime, timedelta
 from urllib.parse import quote, urljoin
@@ -864,6 +865,29 @@ def _legacy_encoded_id(job_id):
         return job_id
     return '/'.join(quote(p, safe='') for p in parts[:-1]) + '/' + parts[-1]
 
+def _broken_id_variants(clean_id):
+    """All historical broken forms this file's id may be stored under:
+      1. legacy: directory components percent-encoded (pre-double-encoding fix)
+      2. mojibake: UTF-8 listing decoded as Latin-1 (e.g. 'BURN·E' → 'BURNÂ·E')
+         — happened when the remote server omitted the charset header
+      3. legacy encoding of the mojibake form (both eras combined)
+    Download URLs built from any of these 404 on the real source, so rows
+    stored under them can never encode successfully until migrated."""
+    variants = []
+    legacy = _legacy_encoded_id(clean_id)
+    if legacy != clean_id:
+        variants.append(legacy)
+    try:
+        moji = clean_id.encode('utf-8').decode('latin-1')
+        if moji != clean_id:
+            variants.append(moji)
+            moji_legacy = _legacy_encoded_id(moji)
+            if moji_legacy != moji:
+                variants.append(moji_legacy)
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        pass
+    return variants
+
 def scan_remote_http(url, prefix="", depth=0, known_ids=None):
     """
     Recursively scans an HTTP directory listing for video files.
@@ -892,15 +916,25 @@ def scan_remote_http(url, prefix="", depth=0, known_ids=None):
 
     if not r or r.status_code != 200: return
 
+    # Directory listings are almost always UTF-8, but when the server omits
+    # the charset, `requests` falls back to Latin-1 (an HTTP/1.1 relic).
+    # That turns e.g. "BURN·E.2008" into the mojibake "BURNÂ·E.2008", which
+    # then percent-encodes to the wrong bytes and 404s on every download.
+    if 'charset' not in (r.headers.get('Content-Type') or '').lower():
+        r.encoding = 'utf-8'
+
     try:
         links = re.findall(r'href=["\']([^"\'<>]+)["\']', r.text)
-        
+
         for link in links:
+            # hrefs are HTML-escaped attributes: "&amp;" in a listing means a
+            # literal "&" in the real filename.
+            link = html_lib.unescape(link)
             if link.startswith('?') or link.startswith('/') or link in ['../', './']: continue
             if "parent directory" in link.lower(): continue
-            
+
             full_url = urljoin(url, link)
-            
+
             if link.endswith('/'):
                 time.sleep(0.2) # Tiny delay to prevent hammering
                 # Recursively yield results from subdirectories.
@@ -916,10 +950,11 @@ def scan_remote_http(url, prefix="", depth=0, known_ids=None):
                 clean_name = unquote(link)
                 clean_id = f"{prefix}{clean_name}"
 
-                # Already tracked (under the current or legacy-encoded id)?
-                # Skip the per-file HEAD request — the dominant cost of a rescan.
-                if known_ids is not None and (clean_id in known_ids
-                                              or _legacy_encoded_id(clean_id) in known_ids):
+                # Already tracked under the correct id? Skip the per-file HEAD
+                # request — the dominant cost of a rescan. Files tracked only
+                # under a BROKEN historical id are deliberately not skipped:
+                # process_batch migrates those rows to the working id.
+                if known_ids is not None and clean_id in known_ids:
                     continue
 
                 size = 0
@@ -953,6 +988,7 @@ def _scan_and_queue_inner():
         if not file_batch: return
         
         count_new = 0
+        migrations = []
         # 1. Update Database
         with db_lock:
             conn = db_handler.get_connection()
@@ -975,29 +1011,46 @@ def _scan_and_queue_inner():
 
                     cursor.execute("SELECT id FROM jobs WHERE id=?", (job_id,))
                     if not cursor.fetchone():
-                        # Also check the legacy partially-encoded ID format produced
-                        # before the double-encoding bug fix.  The old scanner left
-                        # subdir components percent-encoded (e.g. BURN%C2%B7E.../)
-                        # while decoding only the filename.  After the fix, all path
-                        # components are decoded, so the IDs differ even for the same
-                        # file.  We normalise before inserting to avoid re-queuing
-                        # files that are already done or in-progress.
-                        _legacy_id = _legacy_encoded_id(job_id)
-                        if _legacy_id != job_id:
-                            cursor.execute("SELECT id FROM jobs WHERE id=?", (_legacy_id,))
-                            if cursor.fetchone():
-                                continue  # already exists under the old encoded ID
+                        # The same file may be tracked under a BROKEN historical
+                        # id (percent-encoded directories from the old scanner,
+                        # or mojibake from charset-less listings — see
+                        # _broken_id_variants). Those ids build download URLs
+                        # that 404 forever, so repair the row in place instead
+                        # of inserting a duplicate.
+                        migrated = False
+                        for variant in _broken_id_variants(job_id):
+                            cursor.execute("SELECT status FROM jobs WHERE id=?", (variant,))
+                            vrow = cursor.fetchone()
+                            if vrow is None:
+                                continue
+                            cursor.execute("UPDATE jobs SET id=?, filename=? WHERE id=?",
+                                           (job_id, fname, variant))
+                            cursor.execute("UPDATE chunks SET job_id=? WHERE job_id=?", (job_id, variant))
+                            cursor.execute("UPDATE earnings SET job_id=? WHERE job_id=?", (job_id, variant))
+                            if vrow[0] in ('failed', 'permanently_failed'):
+                                # Its failures were caused by the broken id
+                                # (unreachable download URL) — give it a clean slate.
+                                cursor.execute("UPDATE jobs SET status='queued', fail_count=0, progress=0, "
+                                               "worker_id=NULL, started_at=NULL, chunked=0, chunkable=NULL, "
+                                               "last_updated=? WHERE id=?", (datetime.now(), job_id))
+                            migrations.append((variant, job_id, vrow[0]))
+                            migrated = True
+                            break
+                        if migrated:
+                            continue
                         cursor.execute(
-                            "INSERT INTO jobs (id, filename, status, last_updated, file_size, source_type, source_url, content_profile, fail_count) VALUES (?, ?, 'queued', ?, ?, ?, ?, ?, 0)", 
+                            "INSERT INTO jobs (id, filename, status, last_updated, file_size, source_type, source_url, content_profile, fail_count) VALUES (?, ?, 'queued', ?, ?, ?, ?, ?, 0)",
                             (job_id, fname, datetime.now(), fsize, src_type, src_url, profile)
                         )
                         count_new += 1
                 conn.commit()
             finally:
                 conn.close()
-        
+
         if count_new > 0:
             print(f"[*] Added {count_new} new files to Database...")
+        for old_id, new_id, old_status in migrations:
+            log_event("INFO", f"Repaired broken job id: '{old_id}' -> '{new_id}' (was {old_status}).", new_id)
 
     # --- 1. Scan Local ---
     print(f"[*] Scanning LOCAL Source: {SOURCE_DIRECTORY} ...")


### PR DESCRIPTION
## Summary

Fixes the reported `BURNÂ·E.2008` problem — the real folder is `BURN·E.2008`, and the `Â·` spelling is the tell: UTF-8 bytes decoded as Latin-1.

## Root cause

The remote source serves directory listings **without a `charset` in the Content-Type header**. The `requests` library then falls back to Latin-1 (an HTTP/1.1 relic), so the scanner read — and stored as the job id — the mojibake form of the name. Every download URL built from that id percent-encodes the wrong bytes (`%C3%82%C2%B7` instead of `%C2%B7`), the source 404s on every attempt, and the job burns through its 5 retries into `permanently_failed`.

## Fixes

1. **Prevention:** charset-less listings are now decoded as UTF-8, so mojibake ids can no longer form. hrefs are also HTML-unescaped (`&amp;` in a listing is a literal `&` in the filename — the same failure class).
2. **Repair of existing data:** during a scan, if a file's correct id is missing from the DB but a broken historical form of it exists — mojibake, the older percent-encoded-directories form (already noted in code comments), or both combined — the existing row is **renamed in place** (jobs + chunks + earnings all follow) instead of a duplicate being inserted. Rows that had failed *because of* the broken id are requeued with a fresh `fail_count`, since nothing was wrong with the file itself.

No action needed beyond updating: the next scan (startup or the admin Rescan button) repairs the affected rows and re-queues them — you'll see `Repaired broken job id: ...` lines in the system log.

## Testing

Reproduced end-to-end against a purpose-built remote HTTP server that serves raw-UTF-8 listings with no charset (mimicking the real source):
- A seeded mojibake row (`permanently_failed`, fail_count 5) and a seeded legacy percent-encoded row were both repaired on the next scan — correct ids, requeued, no duplicates.
- `BURN·E.2008` then chunk-encoded successfully across 2 worker threads: correctly encoded download URL, frame-exact output (1500/1500), saved as `completed_media/BURN·E.2008/BURN·E.2008.mp4`, wallet earnings credited.
- `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_