### PR TITLE
Audit hardening + working browser AV1 worker (small & large files) + WASM build recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,17 @@ By default the manager splits long videos into ~5-minute **chunks** so that mult
 - Old workers and the browser-based web worker keep using `/get_job` untouched.
 - Watermarks (`--watermark`) are skipped on chunks so the final video is consistent.
 
+### Server-side segmentation (browser workers on big files)
+
+Browser workers can't range-stream a multi-GB source (32-bit WebAssembly, and the wasm has no network), so they'd otherwise be limited to small whole files. Segmentation fixes that:
+
+- A browser node calls `/get_chunk?video_only=1` and is assigned one of the job's existing video chunks (same plan the desktop workers use — nothing about the boundaries changes).
+- It fetches that chunk's bytes from **`/download_segment`**, which stream-copies (`-c copy`, no re-encode) just a small, keyframe-aligned segment covering the chunk's time range and returns it with `X-Segment-Lead` / `X-Segment-Duration` headers.
+- The browser seeks by the lead and encodes exactly `[start, start+dur]` — identical to what a native chunk worker produces — then uploads via `/upload_chunk`.
+- The whole-file **audio** chunk is skipped by browser nodes (`video_only`); a native worker encodes it. The manager assembles as usual.
+
+So a browser volunteer only ever downloads ~one chunk's worth of data (e.g. ~80 MB for a 5-min slice of a 2 GB file), never the whole source. Boundaries come from the single per-job chunk plan, so browser and desktop chunks tile identically.
+
 **Config** (`config.py`, both optional):
 
 ```python
@@ -350,7 +361,9 @@ Workers can attach a FractumCoin wallet address with `--wallet ADDR` (or `&walle
 Volunteers can encode small files directly in their browser — no Python, no FFmpeg install. The manager serves an in-browser node at **`/web`** (linked from the dashboard) that runs a purpose-built FFmpeg WebAssembly bundle with **SVT-AV1 + Opus** compiled in, using the same targets as the native worker (preset 2, CRF 63, 480p, mono Opus).
 
 - The page authenticates automatically (the worker token is injected server-side).
-- It only accepts small source files — set **MAX SOURCE MB** on the page (default 150). Browser encoding is memory-bound (32-bit WebAssembly), so large files can crash the tab; the manager filters jobs by that size.
+- **Big files, too:** browser nodes take chunks of large videos via *server-side segmentation* — the manager stream-copies just the piece for one chunk into a small standalone file and sends that, so the browser never downloads a multi-GB source. See "Server-side segmentation" below.
+- Whole-file browser jobs still accept only small sources — set **MAX SOURCE MB** on the page (default 150). Browser encoding is memory-bound (32-bit WebAssembly), so large *whole* files can crash the tab; the manager filters jobs by that size.
+- **Rebuilding the WASM:** the FFmpeg→WebAssembly bundle (SVT-AV1 + Opus) is rebuilt reproducibly with the Docker recipe in [`wasm-build/`](wasm-build/README.md) — use it to compile a newer AV1.
 - Threads require cross-origin isolation; the manager already sends the needed `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy` headers, and the `.wasm` is served with the correct `application/wasm` type.
 - Subtitles are dropped in the browser (no `ffprobe` in the wasm build to filter subtitle types safely); output is video + Opus audio.
 - A `WALLET` field on the page credits FractumCoin earnings just like the native `--wallet` flag.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,18 @@ Workers can attach a FractumCoin wallet address with `--wallet ADDR` (or `&walle
 
 ---
 
+## Browser Worker (no install)
+
+Volunteers can encode small files directly in their browser — no Python, no FFmpeg install. The manager serves an in-browser node at **`/web`** (linked from the dashboard) that runs a purpose-built FFmpeg WebAssembly bundle with **SVT-AV1 + Opus** compiled in, using the same targets as the native worker (preset 2, CRF 63, 480p, mono Opus).
+
+- The page authenticates automatically (the worker token is injected server-side).
+- It only accepts small source files — set **MAX SOURCE MB** on the page (default 150). Browser encoding is memory-bound (32-bit WebAssembly), so large files can crash the tab; the manager filters jobs by that size.
+- Threads require cross-origin isolation; the manager already sends the needed `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy` headers, and the `.wasm` is served with the correct `application/wasm` type.
+- Subtitles are dropped in the browser (no `ffprobe` in the wasm build to filter subtitle types safely); output is video + Opus audio.
+- A `WALLET` field on the page credits FractumCoin earnings just like the native `--wallet` flag.
+
+> The browser worker is best for casual, low-power contributors on small files. Native workers remain far faster and handle the large files.
+
 ## Utility Scripts
 
 ### `maintenance_tool.py`

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Pulls the latest code from git and restarts the service. Run on the manager host
 ## Security Notes
 
 - Set a strong `WORKER_SECRET` and `ADMIN_PASS` in `config.py` before exposing the server publicly.
+- `REQUIRE_WORKER_TOKEN` (default **True**) makes `WORKER_SECRET` an actual gate: worker endpoints now reject requests that present **no** token, not just wrong ones. Regular workers always send the token, so they are unaffected. Set it to `False` only if you intentionally run a fully open, anonymous-worker manager.
 - Put the server behind a reverse proxy (nginx / Caddy) with HTTPS in production.
 - `ADMIN_PASS` is used for HTTP Basic Auth on the `/admin` route. Do not reuse a password you use elsewhere.
 - Workers are validated against a minimum version (`MIN_CLIENT_VERSION` in `manager.py`). Outdated workers are denied jobs until they auto-update.

--- a/config.py.example
+++ b/config.py.example
@@ -16,8 +16,15 @@ SERVER_URL_DISPLAY = "https://encode.fractumseraph.net/"
 ADMIN_USER = "admin"
 ADMIN_PASS = "changeme"  # [!] CHANGE THIS!
 # Security Tokens (Generate new random strings for production)
-WORKER_SECRET = "ChangeThisToALongRandomString" 
+WORKER_SECRET = "ChangeThisToALongRandomString"
 SECRET_KEY = "ChangeThisToAnotherRandomString"
+
+# Require workers to present WORKER_SECRET (X-Worker-Token header or ?token=).
+# When True (default), requests with NO token are rejected — previously a
+# missing token was waved through, so the secret gated nothing. Regular
+# workers already send the token, so they are unaffected. Set False only if
+# you intentionally run a fully open, anonymous-worker manager.
+REQUIRE_WORKER_TOKEN = True
 
 # ==============================================================================
 # FILE & DIRECTORY SETTINGS

--- a/manager.py
+++ b/manager.py
@@ -1366,7 +1366,16 @@ def _fast_hash_file(path, nbytes=_HASH_BYTES):
     return h.hexdigest()
 
 @app.route('/')
+@app.route('/dashboard')
 def dashboard(): return render_template('dashboard.html')
+
+@app.route('/web')
+@app.route('/node')
+def web_worker():
+    # In-browser encoder page. The worker token is injected so a volunteer can
+    # just open the page and contribute (same exposure as /install, which by
+    # policy also embeds the secret). Safely embedded via |tojson in the page.
+    return render_template('web_worker.html', worker_token=WORKER_SECRET)
 
 @app.route('/admin')
 @limiter.limit("5 per minute") 

--- a/manager.py
+++ b/manager.py
@@ -25,7 +25,7 @@ except ImportError:
     exit(1)
 
 # Flask & Extensions
-from flask import Flask, request, jsonify, render_template, send_from_directory, send_file, Response, abort
+from flask import Flask, request, jsonify, render_template, send_from_directory, send_file, Response, abort, after_this_request
 from werkzeug.exceptions import HTTPException
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -688,15 +688,19 @@ def _split_claimed_job(job):
         finally:
             conn.close()
 
-def _assign_pending_chunk(worker_id, folder_filter, max_size_mb):
+def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=False):
     """Hand the oldest pending chunk to a worker. Prioritizes the earliest-started
-    job so the swarm finishes one video before spilling into the next."""
+    job so the swarm finishes one video before spilling into the next.
+    video_only=True (browser workers) skips the whole-file audio chunk, which
+    they can't segment; a native worker encodes the audio track."""
     with db_lock:
         conn = db_handler.get_connection()
         conn.row_factory = sqlite3.Row
         try:
             params = []
             query_parts = ["c.status='pending'", "j.status='processing'", "COALESCE(j.chunked,0)=1"]
+            if video_only:
+                query_parts.append("c.kind='video'")
             if folder_filter:
                 query_parts.append("j.id LIKE ?")
                 params.append(f"{folder_filter}%")
@@ -732,6 +736,11 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb):
             c.execute("UPDATE jobs SET last_updated=? WHERE id=?", (now, chunk['job_id']))
             conn.commit()
             chunk['download_url'] = build_download_url(chunk['job_id'], chunk['source_type'], chunk.pop('source_url'))
+            # Browser workers can't range-stream a multi-GB source, so they fetch
+            # a small pre-cut segment for this chunk instead (see /download_segment).
+            if chunk['kind'] == 'video':
+                chunk['segment_url'] = (f"{SERVER_URL_DISPLAY.rstrip('/')}/download_segment"
+                                        f"?job_id={quote(chunk['job_id'], safe='')}&chunk_index={chunk['chunk_index']}")
             return chunk
         finally:
             conn.close()
@@ -1545,6 +1554,9 @@ def get_chunk():
     series_id = request.args.get('series_id')
     worker_id = sanitize_input(request.args.get('worker_id'))
     worker_version = sanitize_input(request.args.get('version'))
+    # Browser workers pass video_only=1: they fetch a pre-cut segment per video
+    # chunk and can't handle the whole-file audio chunk.
+    video_only = request.args.get('video_only') in ('1', 'true', 'yes')
 
     if is_worker_banned(worker_id):
         return jsonify({"status": "empty", "message": "Unauthorized"}), 403
@@ -1554,7 +1566,7 @@ def get_chunk():
     try:
         folder_filter = _resolve_folder_filter(series_id)
 
-        chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb)
+        chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=video_only)
         if chunk is None:
             if SPLIT_LOCK.acquire(blocking=False):
                 # No pending chunks anywhere — split the next queued job.
@@ -1566,7 +1578,7 @@ def get_chunk():
                 try:
                     job = _claim_job_for_split(folder_filter, max_size_mb)
                     if job is not None and _split_claimed_job(job):
-                        chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb)
+                        chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=video_only)
                 finally:
                     SPLIT_LOCK.release()
             else:
@@ -1582,6 +1594,114 @@ def get_chunk():
     except Exception as e:
         log_event("ERROR", f"get_chunk failed: {e}")
         return jsonify({"status": "error"}), 500
+
+# Small tail past the chunk end so the segment reliably contains the full
+# [start, start+dur] window after keyframe/rounding effects. With -copyts + -to
+# the end is anchored to an ABSOLUTE timestamp, so this need only cover rounding
+# (not the GOP length — unlike a -t-based cut, which measures from the keyframe).
+_SEGMENT_GUARD_SEC = 2.0
+
+@app.route('/download_segment', methods=['GET'])
+@requires_worker_auth
+def download_segment():
+    """Stream a small, standalone, keyframe-aligned segment covering one video
+    chunk's time range — so a browser worker can encode a chunk of a multi-GB
+    source without downloading the whole file.
+
+    The cut is a lossless stream copy with -copyts, so the segment keeps the
+    source's absolute timestamps: the worker then does an accurate
+    `-ss <start> -t <dur>` seek INSIDE the segment and gets exactly the same
+    [start, start+dur] window a native chunk worker produces — so browser and
+    desktop chunks tile identically at assembly.
+    """
+    job_id = (request.args.get('job_id') or '').strip()
+    try:
+        chunk_index = int(request.args.get('chunk_index'))
+    except (TypeError, ValueError):
+        return jsonify({"status": "error", "message": "chunk_index required"}), 400
+    if not job_id:
+        return jsonify({"status": "error", "message": "job_id required"}), 400
+
+    with db_lock:
+        conn = db_handler.get_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            c = conn.cursor()
+            c.execute("SELECT start_sec, duration_sec FROM chunks WHERE job_id=? AND kind='video' AND chunk_index=?",
+                      (job_id, chunk_index))
+            crow = c.fetchone()
+            c.execute("SELECT source_type, source_url FROM jobs WHERE id=?", (job_id,))
+            jrow = c.fetchone()
+        finally:
+            conn.close()
+    if crow is None or jrow is None:
+        return abort(404)
+
+    start = float(crow['start_sec'] or 0)
+    dur = float(crow['duration_sec'] or 0)
+    if jrow['source_type'] == 'remote':
+        src = build_download_url(job_id, 'remote', jrow['source_url'])
+        src_input = src
+    else:
+        src_input = os.path.join(SOURCE_DIRECTORY, job_id.replace('/', os.sep))
+        if not os.path.isfile(src_input):
+            return abort(404)
+
+    seg_dir = os.path.join("temp_uploads", "segments")
+    os.makedirs(seg_dir, exist_ok=True)
+    seg_path = os.path.join(seg_dir, f"{uuid.uuid4().hex}.mkv")
+
+    # -copyts keeps absolute timestamps; -ss before -i seeks to the keyframe at
+    # or before `start`; -to anchors the end to an ABSOLUTE time so the window is
+    # always covered regardless of GOP length. Matroska handles the copied
+    # stream + preserved timestamps cleanly and streams progressively.
+    input_flags = ['-ss', f"{start:.3f}"]
+    if jrow['source_type'] == 'remote':
+        input_flags = ['-headers', f"X-Worker-Token: {WORKER_SECRET}\r\n"] + input_flags
+    cmd = (['ffmpeg', '-y', '-copyts'] + input_flags +
+           ['-i', src_input, '-to', f"{start + dur + _SEGMENT_GUARD_SEC:.3f}",
+            '-map', '0:v:0', '-c', 'copy', '-f', 'matroska', seg_path])
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        if res.returncode != 0 or not os.path.exists(seg_path) or os.path.getsize(seg_path) == 0:
+            try:
+                if os.path.exists(seg_path): os.remove(seg_path)
+            except OSError: pass
+            log_event("WARN", f"Segment extraction failed for chunk {chunk_index} (rc={res.returncode})", job_id)
+            return jsonify({"status": "error", "message": "segment extraction failed"}), 500
+    except Exception as e:
+        try:
+            if os.path.exists(seg_path): os.remove(seg_path)
+        except OSError: pass
+        log_event("WARN", f"Segment extraction error for chunk {chunk_index}: {e}", job_id)
+        return jsonify({"status": "error", "message": "segment extraction error"}), 500
+
+    # The copied segment starts at the keyframe at-or-before `start`, and input
+    # -ss on it is start_time-relative, so the worker must seek by the LEAD
+    # (start - segment_start_time), not by absolute `start`. Probe the header
+    # for that start_time and hand the worker the exact lead + duration.
+    seg_start = 0.0
+    try:
+        pr = subprocess.run(['ffprobe', '-v', 'error', '-show_entries', 'format=start_time',
+                             '-of', 'default=nw=1:nk=1', seg_path],
+                            capture_output=True, text=True, timeout=30)
+        seg_start = float((pr.stdout or '0').strip() or 0)
+    except Exception:
+        seg_start = 0.0
+    lead = max(0.0, start - seg_start)
+
+    @after_this_request
+    def _cleanup(response):
+        try: os.remove(seg_path)
+        except OSError: pass
+        return response
+
+    resp = send_file(seg_path, mimetype='video/x-matroska', as_attachment=True,
+                     download_name=f"segment_{chunk_index}.mkv")
+    # Worker reads these to run: -ss <lead> -i seg -t <duration>  (accurate seek)
+    resp.headers['X-Segment-Lead'] = f"{lead:.3f}"
+    resp.headers['X-Segment-Duration'] = f"{dur:.3f}"
+    return resp
 
 @app.route('/upload_chunk', methods=['POST'])
 @requires_worker_auth
@@ -2329,20 +2449,23 @@ def handle_exception(e):
     return "Internal Server Error", 500
 
 def sweep_quarantine():
-    """Remove stale files from the quarantine upload directory."""
-    quarantine_dir = os.path.join("temp_uploads", "quarantine")
-    if not os.path.exists(quarantine_dir): return
+    """Remove stale files from the quarantine + segment temp directories."""
     cutoff = time.time() - 3600  # 1 hour
     count = 0
-    for fname in os.listdir(quarantine_dir):
-        fpath = os.path.join(quarantine_dir, fname)
-        try:
-            if os.path.isfile(fpath) and os.path.getmtime(fpath) < cutoff:
-                os.remove(fpath)
-                count += 1
-        except Exception: pass
+    # segment temp files are normally deleted right after send; sweep covers
+    # aborted downloads where after_this_request didn't fire.
+    for sub in ("quarantine", "segments"):
+        d = os.path.join("temp_uploads", sub)
+        if not os.path.exists(d): continue
+        for fname in os.listdir(d):
+            fpath = os.path.join(d, fname)
+            try:
+                if os.path.isfile(fpath) and os.path.getmtime(fpath) < cutoff:
+                    os.remove(fpath)
+                    count += 1
+            except Exception: pass
     if count > 0:
-        print(f"[*] Quarantine sweep: removed {count} stale file(s).")
+        print(f"[*] Temp sweep: removed {count} stale file(s).")
 
 def maintenance_loop():
     while True:

--- a/manager.py
+++ b/manager.py
@@ -84,6 +84,14 @@ try:
     except ImportError:
         CHUNK_DURATION_SEC = 300
 
+    # [SECURITY] When True, worker endpoints require a valid X-Worker-Token
+    # (or ?token=). Requests with NO token are rejected, not waved through.
+    # Regular workers already send the token, so they are unaffected.
+    try:
+        from config import REQUIRE_WORKER_TOKEN
+    except ImportError:
+        REQUIRE_WORKER_TOKEN = True
+
 except ImportError:
     print("[!] Critical Error: config.py not found.")
     exit(1)
@@ -151,15 +159,40 @@ class DatabaseHandler:
                 self.mode = 'disk'
 
     def _load_to_ram(self):
-        """Copies Disk DB to RAM at startup."""
+        """Load the DB into RAM at startup.
+
+        A plain restart (systemd) does NOT clear /dev/shm, so a RAM copy from
+        the previous run can survive and be NEWER than the disk file (the disk
+        sync only runs every 60s). Blindly copying disk->ram would roll back up
+        to a minute of completed jobs and earnings. So: if the surviving RAM
+        file is newer, recover it to disk first instead of overwriting it.
+        """
         with db_lock:
             # Ensure disk file exists to copy
             if not os.path.exists(self.disk_path):
                 open(self.disk_path, 'a').close()
-            
+
+            if (os.path.exists(self.ram_path)
+                    and os.path.getmtime(self.ram_path) > os.path.getmtime(self.disk_path) + 1):
+                print("[!] DB Mode: surviving RAM copy is newer than disk — recovering it to disk.")
+                try:
+                    src = sqlite3.connect(self.ram_path)
+                    dst = sqlite3.connect(self.disk_path)
+                    with dst:
+                        src.backup(dst)
+                    dst.close(); src.close()
+                except Exception as e:
+                    print(f"[!] RAM->disk recovery failed ({e}); keeping RAM copy as-is.")
+                # RAM copy is already the freshest; leave it in place.
+                try:
+                    os.chmod(self.ram_path, 0o666)
+                except Exception:
+                    pass
+                return
+
             # Copy to RAM
             shutil.copy2(self.disk_path, self.ram_path)
-            
+
             # Set permissions
             try:
                 os.chmod(self.ram_path, 0o666)
@@ -296,7 +329,12 @@ def csrf_protect():
         origin = request.headers.get('Origin')
         referer = request.headers.get('Referer')
         target = origin or referer or ""
-        if request.host not in target:
+        # Compare the actual host component, not a substring: a naive
+        # `request.host not in target` passes for evil-<host>.attacker.com
+        # because it merely contains the host as a substring.
+        from urllib.parse import urlparse
+        target_host = urlparse(target).netloc
+        if not target_host or target_host != request.host:
              return jsonify({"status": "error", "message": "CSRF Blocked: Origin Mismatch"}), 403
 
 def check_auth(u, p):
@@ -321,8 +359,15 @@ def requires_worker_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         token = request.headers.get('X-Worker-Token') or request.args.get('token')
-        if token is None: return f(*args, **kwargs)
-        if token != WORKER_SECRET:
+        if token is None:
+            # Previously a missing token was waved through entirely, so the
+            # shared secret gated nothing. When REQUIRE_WORKER_TOKEN is on we
+            # now reject tokenless requests too (regular workers always send
+            # one). Left off => the old open behavior for a fully public setup.
+            if REQUIRE_WORKER_TOKEN:
+                return jsonify({"status": "error", "message": "Worker token required"}), 401
+            return f(*args, **kwargs)
+        if not secrets.compare_digest(str(token), str(WORKER_SECRET)):
             return jsonify({"status": "error", "message": "Unauthorized Worker"}), 401
         return f(*args, **kwargs)
     return decorated
@@ -813,8 +858,21 @@ def _assemble_job(job_id):
         with db_lock:
             conn = db_handler.get_connection()
             try:
-                conn.execute("UPDATE jobs SET status='completed', progress=100, duration=?, worker_id=?, last_updated=? WHERE id=?",
-                             (int(src_dur / 60), f"(chunked x{len(workers)})", datetime.now(), job_id))
+                c = conn.cursor()
+                # Guard: assembly can take up to an hour (ffmpeg concat). If an
+                # admin reset/deleted the job meanwhile (status left 'processing'
+                # + chunked=1), don't resurrect it or move the file over a job
+                # someone re-claimed whole.
+                c.execute("UPDATE jobs SET status='completed', progress=100, duration=?, worker_id=?, last_updated=? "
+                          "WHERE id=? AND status='processing' AND COALESCE(chunked,0)=1",
+                          (int(src_dur / 60), f"(chunked x{len(workers)})", datetime.now(), job_id))
+                if c.rowcount != 1:
+                    conn.commit()
+                    log_event("WARN", "Assembled file discarded: job was reset/taken during assembly.", job_id)
+                    try:
+                        if os.path.exists(save_path): os.remove(save_path)
+                    except Exception: pass
+                    return
                 if warn:
                     conn.execute("UPDATE jobs SET warnings = COALESCE(warnings || ' | ', '') || ? WHERE id=?",
                                  (warn, job_id))
@@ -1095,30 +1153,52 @@ def _scan_and_queue_inner():
         # Commit any remaining files
         if remote_batch:
             process_batch(remote_batch)
-            
+
+    # Folder set may have changed — refresh the cached series list.
+    try:
+        get_series_list(force_refresh=True)
+    except Exception:
+        pass
     print("[*] Scan complete.")
 
-def get_series_list():
-    try:
-        # [FIX] Allow series listing even in hybrid mode
-        if not os.path.exists(SOURCE_DIRECTORY): return [], []
-        
-        folders = sorted([d for d in os.listdir(SOURCE_DIRECTORY) if os.path.isdir(os.path.join(SOURCE_DIRECTORY, d))])
-        folder_set = set(folders)
-        mapping = {}
-        stale_keys = []
-        
-        if os.path.exists('series_names.json'):
-            try:
-                mapping = json.load(open('series_names.json', 'r'))
-                stale_keys = [k for k in mapping if k not in folder_set]
-                if stale_keys:
-                    print(f"[!] series_names.json has {len(stale_keys)} stale key(s): {', '.join(stale_keys[:5])}")
-            except: pass
-            
-        return [{"id": i+1, "folder": f, "name": mapping.get(f, f)} for i, f in enumerate(folders)], stale_keys
-    except:
-        return [], []
+# Cache for get_series_list: it hits the filesystem (a directory listing + a
+# stat per entry + a JSON read), and it was being called on every /get_job and
+# /get_chunk poll that carried a series_id — dozens of listings per second, and
+# painful when SOURCE_DIRECTORY is a network mount. 60s TTL, like _BANNED_CACHE.
+_SERIES_CACHE = None
+_SERIES_CACHE_TIME = 0.0
+_SERIES_CACHE_LOCK = threading.Lock()
+
+def get_series_list(force_refresh=False):
+    global _SERIES_CACHE, _SERIES_CACHE_TIME
+    with _SERIES_CACHE_LOCK:
+        now = time.time()
+        if not force_refresh and _SERIES_CACHE is not None and now - _SERIES_CACHE_TIME < 60:
+            return _SERIES_CACHE
+        try:
+            # [FIX] Allow series listing even in hybrid mode
+            if not os.path.exists(SOURCE_DIRECTORY):
+                _SERIES_CACHE = ([], []); _SERIES_CACHE_TIME = now
+                return _SERIES_CACHE
+
+            folders = sorted([d for d in os.listdir(SOURCE_DIRECTORY) if os.path.isdir(os.path.join(SOURCE_DIRECTORY, d))])
+            folder_set = set(folders)
+            mapping = {}
+            stale_keys = []
+
+            if os.path.exists('series_names.json'):
+                try:
+                    mapping = json.load(open('series_names.json', 'r'))
+                    stale_keys = [k for k in mapping if k not in folder_set]
+                    if stale_keys:
+                        print(f"[!] series_names.json has {len(stale_keys)} stale key(s): {', '.join(stale_keys[:5])}")
+                except: pass
+
+            result = ([{"id": i+1, "folder": f, "name": mapping.get(f, f)} for i, f in enumerate(folders)], stale_keys)
+            _SERIES_CACHE = result; _SERIES_CACHE_TIME = now
+            return result
+        except:
+            return _SERIES_CACHE if _SERIES_CACHE is not None else ([], [])
 
 # ==============================================================================
 # DATABASE INIT
@@ -1196,6 +1276,14 @@ def init_db():
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_chunks_status ON chunks(status)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_chunks_job ON chunks(job_id)")
+        # Composite index for the job-pick query (status + source_type filter,
+        # ORDER BY id) so /get_job and _claim_job_for_split do an index seek
+        # instead of scanning + sorting the whole queued set every poll.
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_jobs_pick ON jobs(status, source_type, id)")
+        # last_updated drives the dashboard history + admin job list sort.
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_jobs_last_updated ON jobs(last_updated)")
+        # id drives the system_logs prune + the LIMIT view.
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_syslogs_id ON system_logs(id)")
 
         # FractumCoin earnings ledger: one row per VERIFIED upload (whole file
         # or video chunk). Durable payout record — unlike the jobs/chunks
@@ -1216,6 +1304,8 @@ def init_db():
         ''')
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_earnings_wallet ON earnings(wallet)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_earnings_worker ON earnings(worker_id)")
+        # timestamp drives the 24h/30d scoreboard filters.
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_earnings_ts ON earnings(timestamp)")
 
         # One-time backfill so historical scoreboard credit carries over into
         # the ledger (wallet unknown for past work — recorded as NULL).
@@ -1628,6 +1718,22 @@ def upload_result():
         duration = 0
     
     if 'file' in request.files and job_id:
+        # Reject stale/misdirected uploads BEFORE touching disk: a job that was
+        # since split into chunks (chunked=1) or already completed must not be
+        # overwritten by a straggler whole-file worker.
+        with db_lock:
+            conn = db_handler.get_connection()
+            try:
+                c = conn.cursor()
+                c.execute("SELECT status, COALESCE(chunked, 0) FROM jobs WHERE id=?", (job_id,))
+                jrow = c.fetchone()
+            finally:
+                conn.close()
+        if jrow is None:
+            return jsonify({"status": "error", "message": "unknown job"}), 404
+        if jrow[1] == 1 or jrow[0] == 'completed':
+            return jsonify({"status": "stale", "message": "Job no longer accepts a whole-file upload"}), 409
+
         new_filename = os.path.splitext(job_id)[0] + ".mp4"
         quarantine_dir = os.path.join("temp_uploads", "quarantine")
         os.makedirs(quarantine_dir, exist_ok=True)
@@ -1640,8 +1746,15 @@ def upload_result():
             os.remove(temp_path)
             with db_lock:
                 conn = db_handler.get_connection()
-                conn.execute("UPDATE jobs SET status='failed', last_updated=? WHERE id=?", (datetime.now(), job_id))
-                conn.commit(); conn.close()
+                try:
+                    # Count the failure so a permanently-broken source doesn't
+                    # loop forever through the new auto-requeue path.
+                    conn.execute("UPDATE jobs SET status='failed', fail_count=COALESCE(fail_count,0)+1, "
+                                 "last_updated=? WHERE id=? AND COALESCE(chunked,0)=0", (datetime.now(), job_id))
+                    conn.execute("UPDATE jobs SET status='permanently_failed' WHERE id=? AND COALESCE(fail_count,0) >= 5", (job_id,))
+                    conn.commit()
+                finally:
+                    conn.close()
             return jsonify({"status": "error", "message": reason}), 400
 
         save_path = os.path.abspath(os.path.join(COMPLETED_DIRECTORY, new_filename))
@@ -1649,15 +1762,17 @@ def upload_result():
              os.remove(temp_path); return jsonify({"status": "error"}), 403
 
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
-        shutil.move(temp_path, save_path) 
+        shutil.move(temp_path, save_path)
 
         with db_lock:
             conn = db_handler.get_connection()
             try:
                 c = conn.cursor()
+                # Guard chunked=0 again (race: split may have happened during
+                # the encode verify/move) and skip double-credit on re-uploads.
                 c.execute("SELECT status FROM jobs WHERE id=?", (job_id,))
                 prev = c.fetchone()
-                c.execute("UPDATE jobs SET status='completed', progress=100, worker_id=?, last_updated=?, duration=? WHERE id=?",
+                c.execute("UPDATE jobs SET status='completed', progress=100, worker_id=?, last_updated=?, duration=? WHERE id=? AND COALESCE(chunked,0)=0",
                     (worker_id, datetime.now(), duration, job_id))
                 # FractumCoin credit: minutes come from ffprobe of the delivered
                 # file, not the worker's claim. A re-upload to an already
@@ -1935,19 +2050,29 @@ def report_status():
     with db_lock:
         conn = db_handler.get_connection()
         try:
-            # COALESCE(chunked,0)=0 guard: a whole-file worker whose timed-out
-            # job was since split into chunks must not clobber the chunked
-            # job's status/worker (that would stall assignment and assembly).
-            sql = "UPDATE jobs SET status=?, worker_id=?, progress=?, last_updated=? WHERE id=? AND COALESCE(chunked, 0)=0"
-            params = [status, worker_id, d.get('progress',0), datetime.now(), d.get('job_id')]
+            job_id_val = d.get('job_id')
+            # Guards on every update:
+            #  - COALESCE(chunked,0)=0: never touch a job that was split into
+            #    chunks (that would stall assignment/assembly).
+            #  - worker_id=?: only the CURRENT owner may report. A stale worker
+            #    whose job was reassigned/completed can't revert it.
+            #  - status NOT IN terminal: never resurrect a completed or
+            #    permanently_failed job.
+            base_where = ("WHERE id=? AND COALESCE(chunked, 0)=0 AND worker_id=? "
+                          "AND status NOT IN ('completed', 'permanently_failed')")
+            sql = f"UPDATE jobs SET status=?, progress=?, last_updated=? {base_where}"
+            params = [status, d.get('progress', 0), datetime.now(), job_id_val, worker_id]
             if d.get('duration', 0) > 0:
-                sql = "UPDATE jobs SET status=?, worker_id=?, progress=?, last_updated=?, duration=? WHERE id=? AND COALESCE(chunked, 0)=0"
-                params.insert(4, d.get('duration'))
+                sql = f"UPDATE jobs SET status=?, progress=?, last_updated=?, duration=? {base_where}"
+                params.insert(3, d.get('duration'))
             conn.execute(sql, tuple(params))
             if status == 'failed':
-                job_id_val = d.get('job_id')
-                conn.execute("UPDATE jobs SET fail_count = COALESCE(fail_count, 0) + 1 WHERE id=? AND COALESCE(chunked, 0)=0", (job_id_val,))
-                conn.execute("UPDATE jobs SET status='permanently_failed' WHERE id=? AND COALESCE(fail_count, 0) >= 5 AND COALESCE(chunked, 0)=0", (job_id_val,))
+                # Only count the failure if this worker actually owned the job
+                # (the UPDATE above changed the row). Re-read to confirm.
+                conn.execute("UPDATE jobs SET fail_count = COALESCE(fail_count, 0) + 1 "
+                             "WHERE id=? AND COALESCE(chunked, 0)=0 AND worker_id=? AND status='failed'",
+                             (job_id_val, worker_id))
+                conn.execute("UPDATE jobs SET status='permanently_failed' WHERE id=? AND COALESCE(fail_count, 0) >= 5 AND status='failed'", (job_id_val,))
             conn.commit()
         finally:
             conn.close()
@@ -1966,8 +2091,11 @@ def api_stats():
             # the audio helper pass earns 0 so chunked jobs count exactly
             # once). The ledger is append-only, so scores survive retries,
             # archives, and chunk cleanup.
-            earn_filter = (" AND timestamp > datetime('now', '-1 day')" if filter_val == '24h'
-                           else " AND timestamp > datetime('now', '-30 days')" if filter_val == '30d' else "")
+            # timestamps are stored with Python datetime.now() (LOCAL time), so
+            # the window must also be computed in local time — datetime('now')
+            # alone is UTC and would skew the window by the server's offset.
+            earn_filter = (" AND timestamp > datetime('now', 'localtime', '-1 day')" if filter_val == '24h'
+                           else " AND timestamp > datetime('now', 'localtime', '-30 days')" if filter_val == '30d' else "")
             c.execute(f"""
                 SELECT CASE WHEN instr(worker_id, '-') > 0 THEN substr(worker_id, 1, instr(worker_id, '-') - 1) ELSE worker_id END as worker_id,
                        CAST(SUM(minutes) AS INTEGER) as total_minutes,
@@ -2020,11 +2148,23 @@ def api_stats():
 @app.route('/api/all_jobs')
 @requires_auth
 def api_all_jobs():
+    # Bounded + optionally status-filtered: returning every one of thousands of
+    # rows as JSON on each admin refresh serialized megabytes under db_lock.
+    try:
+        limit = min(int(request.args.get('limit', 2000)), 10000)
+    except (ValueError, TypeError):
+        limit = 2000
+    status_filter = request.args.get('status')
     with db_lock:
         conn = db_handler.get_connection(); conn.row_factory = sqlite3.Row
         try:
             c = conn.cursor()
-            c.execute("SELECT id, status, worker_id, worker_version, last_updated, warnings FROM jobs ORDER BY last_updated DESC")
+            if status_filter:
+                c.execute("SELECT id, status, worker_id, worker_version, last_updated, warnings FROM jobs "
+                          "WHERE status=? ORDER BY last_updated DESC LIMIT ?", (status_filter, limit))
+            else:
+                c.execute("SELECT id, status, worker_id, worker_version, last_updated, warnings FROM jobs "
+                          "ORDER BY last_updated DESC LIMIT ?", (limit,))
             jobs = [dict(r) for r in c.fetchall()]
         finally:
             conn.close()
@@ -2243,6 +2383,29 @@ def maintenance_loop():
                     for (jid,) in cursor.fetchall():
                         _requeue_job_whole(conn, jid, "no chunk activity for 6h",
                                            penalize=False, disable_chunking=False)
+
+                    # Auto-requeue transiently-failed jobs (fail_count < 5) after
+                    # a short cooldown. Previously a worker-reported 'failed' left
+                    # the job dead until an admin manually clicked Reset Failed;
+                    # /get_job only serves 'queued'. The fail_count<5 retry design
+                    # was never actually wired up for this path.
+                    failed_cutoff = now - timedelta(minutes=10)
+                    cursor.execute(
+                        "UPDATE jobs SET status='queued', progress=0, worker_id=NULL, started_at=NULL, last_updated=? "
+                        "WHERE status='failed' AND COALESCE(fail_count, 0) < 5 AND COALESCE(chunked, 0)=0 AND last_updated < ?",
+                        (now, failed_cutoff))
+                    if cursor.rowcount > 0:
+                        logs_to_write.append(("INFO", f"Auto-requeued {cursor.rowcount} transiently-failed job(s).", None))
+
+                    # Prune the ever-growing system_logs table (nothing else does).
+                    # Keep the most recent ~50k rows; the id index makes this cheap.
+                    cursor.execute("SELECT MAX(id) FROM system_logs")
+                    _max_log_id = cursor.fetchone()[0]
+                    if _max_log_id and _max_log_id > 50000:
+                        cursor.execute("DELETE FROM system_logs WHERE id < ?", (_max_log_id - 50000,))
+                        if cursor.rowcount > 0:
+                            logs_to_write.append(("INFO", f"Pruned {cursor.rowcount} old system_logs row(s).", None))
+
                     conn.commit()
                 finally:
                     conn.close()

--- a/static/web_node.js
+++ b/static/web_node.js
@@ -117,11 +117,94 @@ self.onmessage = async function(e) {
         return; // Don't pass job messages to Emscripten
     }
 
+    // Chunk of a large video: encode one time-slice from a pre-cut segment.
+    if (msg && msg.type === 'run_chunk') {
+        try {
+            await processChunk(msg.chunk);
+        } catch (err) {
+            postMessage({type: 'chunk_error', msg: err.toString()});
+        }
+        return;
+    }
+
     // Pass everything else (e.g. Pthread messages) to Emscripten
     if (emscriptenOnMessage) {
         emscriptenOnMessage(e);
     }
 };
+
+// Encode one video chunk of a large source. The manager streams a small,
+// keyframe-aligned segment (with an accurate lead offset in the response
+// headers); we seek into it and encode exactly [start, start+dur], matching
+// what a native chunk worker produces so assembly tiles perfectly.
+async function processChunk(chunk) {
+    const FS = self.Module.FS || self.FS;
+    const callMain = self.Module.callMain || self.callMain;
+    if (!FS || !callMain) throw new Error(`FFmpeg primitives missing. FS:${!!FS} callMain:${!!callMain}`);
+
+    const segPath = "/tmp/seg_" + Date.now() + ".mkv";
+    const outPath = "/tmp/cout_" + Date.now() + ".mp4";
+    const crf = (chunk.content_profile === 'live_action') ? '57' : '63';
+
+    postMessage({type: 'log', level: 'sys', msg: `Chunk ${chunk.chunk_index} of ${chunk.filename}: downloading segment...`});
+    try {
+        const headers = chunk.token ? { 'X-Worker-Token': chunk.token } : {};
+        const resp = await fetch(chunk.segment_url, { headers });
+        if (!resp.ok) throw new Error("Segment download failed: " + resp.status);
+        // Accurate inner seek offset + duration come from the manager.
+        const lead = parseFloat(resp.headers.get('X-Segment-Lead') || '0') || 0;
+        const dur  = parseFloat(resp.headers.get('X-Segment-Duration') || String(chunk.duration_sec)) || chunk.duration_sec;
+
+        const data = new Uint8Array(await resp.arrayBuffer());
+        try { FS.mkdir('/tmp'); } catch(e) {}
+        FS.writeFile(segPath, data);
+        postMessage({type: 'log', level: 'sys', msg: `Segment ${data.length} bytes; encoding [lead=${lead.toFixed(2)}s dur=${dur.toFixed(2)}s]...`});
+
+        // Same targets as the native chunk path: video-only, SVT-AV1 preset 2,
+        // CRF (profile-aware), 480p, timestamps re-zeroed for clean concat.
+        const args = [
+            '-threads', '1', '-v', 'verbose',
+            '-ss', lead.toFixed(3), '-i', segPath, '-t', dur.toFixed(3),
+            '-map', '0:v:0', '-an', '-sn',
+            '-c:v', 'libsvtav1', '-preset', '2', '-crf', crf,
+            '-pix_fmt', 'yuv420p',
+            '-svtav1-params', 'tune=0:lp=1',
+            '-vf', 'setpts=PTS-STARTPTS,scale=-2:480',
+            '-movflags', '+faststart',
+            outPath
+        ];
+        currentOutputPath = outPath;
+        const ffmpegPromise = new Promise((resolve, reject) => { self.resolveJob = resolve; self.rejectJob = reject; });
+        callMain(args);
+        await ffmpegPromise;
+
+        let exists = false;
+        try { FS.stat(outPath); exists = true; } catch(e) {}
+        if (!exists) throw new Error("FFmpeg produced no chunk output.");
+        const outData = FS.readFile(outPath);
+        const blob = new Blob([outData], { type: 'video/mp4' });
+
+        postMessage({type: 'log', level: 'sys', msg: `Uploading chunk (${outData.length} bytes)...`});
+        const fd = new FormData();
+        fd.append('job_id', chunk.job_id);
+        fd.append('worker_id', chunk.worker_id);
+        fd.append('kind', 'video');
+        fd.append('chunk_index', chunk.chunk_index);
+        if (chunk.wallet) fd.append('wallet', chunk.wallet);
+        fd.append('file', blob, `chunk_${chunk.chunk_index}.mp4`);
+        const up = await fetch('/upload_chunk', {
+            method: 'POST', body: fd,
+            headers: chunk.token ? { 'X-Worker-Token': chunk.token } : {}
+        });
+        if (up.status === 409) { postMessage({type: 'chunk_stale'}); return; }
+        if (!up.ok) throw new Error("Chunk upload failed: " + up.status);
+        postMessage({type: 'chunk_done'});
+    } finally {
+        currentOutputPath = null;
+        try { FS.unlink(segPath); } catch(e) {}
+        try { FS.unlink(outPath); } catch(e) {}
+    }
+}
 
 async function processJob(job) {
     // FS and callMain might be on Module or global scope depending on Emscripten build options

--- a/static/web_node.js
+++ b/static/web_node.js
@@ -185,8 +185,6 @@ async function processJob(job) {
             '-strict', '-2',
             '-c:s', 'mov_text',
             '-svtav1-params', 'logical-processors=2',
-
-'
             outputPath
         ];
 

--- a/static/web_node.js
+++ b/static/web_node.js
@@ -168,23 +168,32 @@ async function processJob(job) {
         postMessage({type: 'log', level: 'sys', msg: "Starting FFmpeg..."});
         
         // STRICT ENCODING CONFIGURATION
+        // Matches the manager's verified target: SVT-AV1 preset 2 / CRF 63, 480p,
+        // mono Opus. Notes specific to the browser build:
+        //  - This wasm has --disable-ffprobe, so we can't inspect streams. We map
+        //    the first video + first (optional) audio explicitly and drop
+        //    subtitles (-sn): blindly transcoding an unknown subtitle codec to
+        //    mov_text is a common hard-failure, and bitmap subs can't convert.
+        //  - A single -svtav1-params: the previous two flags silently overrode
+        //    each other (only the last applied). lp=1 keeps browser memory down.
         const args = [
-            '-threads', '1', 
+            '-threads', '1',
             '-v', 'verbose',
             '-i', inputPath,
+            '-map', '0:v:0',
+            '-map', '0:a:0?',
+            '-sn',
             '-c:v', 'libsvtav1',
             '-preset', '2',
             '-crf', '63',
             '-g', '240',
-            '-pix_fmt', 'yuv420p', 
+            '-pix_fmt', 'yuv420p',
             '-svtav1-params', 'tune=0:lp=1',
             '-vf', 'scale=-2:480',
             '-c:a', 'opus',
             '-b:a', '12k',
             '-ac', '1',
             '-strict', '-2',
-            '-c:s', 'mov_text',
-            '-svtav1-params', 'logical-processors=2',
             outputPath
         ];
 
@@ -231,10 +240,14 @@ async function processJob(job) {
         const formData = new FormData();
         formData.append('job_id', job.id);
         formData.append('worker_id', job.worker_id);
+        if (job.wallet) formData.append('wallet', job.wallet);
         formData.append('file', blob, 'result.mp4');
 
-        const up = await fetch('/upload_result', { method: 'POST', body: formData });
-        if (!up.ok) throw new Error("Upload failed: " + up.statusText);
+        // Auth: the manager now requires the worker token (REQUIRE_WORKER_TOKEN).
+        // Sent as a header so it isn't logged in the URL.
+        const upHeaders = job.token ? { 'X-Worker-Token': job.token } : {};
+        const up = await fetch('/upload_result', { method: 'POST', body: formData, headers: upHeaders });
+        if (!up.ok) throw new Error("Upload failed: " + up.status + " " + up.statusText);
         
         postMessage({type: 'done'});
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -314,7 +314,9 @@
             const tbodyJobs = document.getElementById('job-list');
             const filteredJobs = jobsData.filter(j => {
                 let statusMatch = false;
-                if (j.status === 'failed' && jobFilters.failed) statusMatch = true;
+                // 'permanently_failed' (fail_count >= 5) must show under the
+                // failed filter too, or such jobs become invisible/unmanageable.
+                if ((j.status === 'failed' || j.status === 'permanently_failed') && jobFilters.failed) statusMatch = true;
                 if (j.status === 'completed' && jobFilters.completed) statusMatch = true;
                 if (j.status === 'queued' && jobFilters.queued) statusMatch = true;
                 if (['processing', 'downloading', 'uploading'].includes(j.status) && jobFilters.processing) statusMatch = true;
@@ -332,13 +334,17 @@
             } else {
                 tbodyJobs.innerHTML = filteredJobs.map(j => {
                     const cleanName = j.id.split('/').pop();
-                    const workerDisplay = j.worker_id ? `<span class="worker-tag" onclick="setSearch('${escapeHTML(j.worker_id)}')">${escapeHTML(j.worker_id)}</span>` : '<span style="color:#444">-</span>';
-                    
-                    let actions = `<button onclick="act('${escapeHTML(j.id)}','delete')" style="border-color:var(--neon-red); color:var(--neon-red)">DEL</button>`;
-                    if (j.status === 'failed' || j.status === 'completed') {
-                        actions = `<button onclick="act('${escapeHTML(j.id)}','retry')" style="border-color:var(--neon-green); color:var(--neon-green)">RETRY</button> ` + actions;
+                    // data-* attributes carry the raw id/worker safely (HTML-escaped
+                    // as attribute text); a delegated listener reads them. Building
+                    // JS strings inside onclick broke on ids containing apostrophes
+                    // (e.g. "it's.mkv") and was an injection vector.
+                    const workerDisplay = j.worker_id ? `<span class="worker-tag" data-search="${escapeHTML(j.worker_id)}">${escapeHTML(j.worker_id)}</span>` : '<span style="color:#444">-</span>';
+
+                    let actions = `<button data-act="delete" data-id="${escapeHTML(j.id)}" style="border-color:var(--neon-red); color:var(--neon-red)">DEL</button>`;
+                    if (j.status === 'failed' || j.status === 'permanently_failed' || j.status === 'completed') {
+                        actions = `<button data-act="retry" data-id="${escapeHTML(j.id)}" style="border-color:var(--neon-green); color:var(--neon-green)">RETRY</button> ` + actions;
                     }
-                    actions += ` <button onclick="downloadLog('${escapeHTML(j.id)}')" style="border-color:#555; color:#888; font-size:0.75em;">LOG</button>`;
+                    actions += ` <button data-act="log" data-id="${escapeHTML(j.id)}" style="border-color:#555; color:#888; font-size:0.75em;">LOG</button>`;
 
                     // NEW: Build warning badge
                     let warningBadge = "";
@@ -388,6 +394,19 @@
             document.getElementById('searchInput').value = val;
             applyFilters();
         }
+
+        // Delegated handler for job-row buttons/tags. Attached once to the
+        // persistent tbody, so it survives the innerHTML rebuilds in applyFilters.
+        document.getElementById('job-list').addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-act]');
+            if (btn) {
+                if (btn.dataset.act === 'log') downloadLog(btn.dataset.id);
+                else act(btn.dataset.id, btn.dataset.act);
+                return;
+            }
+            const tag = e.target.closest('[data-search]');
+            if (tag) setSearch(tag.dataset.search);
+        });
 
         function act(id, action) {
             let msg = `${action.toUpperCase()} job?`;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -271,7 +271,11 @@
 
                 <div style="text-align: center; margin-top: 30px;">
                     <a href="/dl/worker" target="_blank" class="modal-btn">DOWNLOAD WORKER.PY</a>
+                    <a href="/web" class="modal-btn">ENCODE IN BROWSER</a>
                 </div>
+                <p style="font-size:0.8em; color:#888; text-align:center; margin-top:8px;">
+                    No install needed — encode small files right in your browser (AV1 via WebAssembly).
+                </p>
 
                 <div style="margin-top: 30px; border-top: 1px dashed var(--neon-purple); padding-top: 20px;">
                     <span class="os-title" style="color: var(--text-light);">:: SERIES ID REFERENCE</span>

--- a/templates/web_worker.html
+++ b/templates/web_worker.html
@@ -230,7 +230,8 @@
     let isRunning = false;
     let worker = null;
     let currentWorkerId = "";
-    let currentJobId = null;   // the job this node is actively encoding, for stop-time release
+    let currentJobId = null;   // the whole-file job this node is encoding, for stop-time release
+    let currentChunk = null;   // {job_id, chunk_index} of an in-flight chunk, for release + heartbeat
 
     // Must be >= manager MIN_CLIENT_VERSION or /get_job returns "Update Required".
     const WEB_WORKER_VERSION = "3.3.0";
@@ -269,12 +270,55 @@
             } catch (e) { /* best effort */ }
             currentJobId = null;
         }
+        // Release an in-flight chunk so the manager reassigns it promptly.
+        if (currentChunk) {
+            try {
+                fetch('/report_chunk' + (WORKER_TOKEN ? ('?token=' + encodeURIComponent(WORKER_TOKEN)) : ''), {
+                    method: 'POST', headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ job_id: currentChunk.job_id, chunk_index: currentChunk.chunk_index,
+                                           kind: 'video', worker_id: currentWorkerId,
+                                           status: 'abandoned', version: WEB_WORKER_VERSION })
+                });
+            } catch (e) { /* best effort */ }
+            currentChunk = null;
+        }
         if (worker) {
             worker.terminate();
             worker = null;
             log("Worker terminated immediately.", 'err');
             toggleButtons(false);
         }
+    }
+
+    // While a chunk encodes (wasm callMain blocks the Worker thread), the page
+    // thread stays free — send periodic heartbeats so the manager's 30-min
+    // stale-chunk sweep never reassigns a chunk we're slowly but actively
+    // encoding. Returns a stop() function.
+    function startChunkHeartbeat(jobId, chunkIndex) {
+        const id = setInterval(() => {
+            fetch('/report_chunk' + (WORKER_TOKEN ? ('?token=' + encodeURIComponent(WORKER_TOKEN)) : ''), {
+                method: 'POST', headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ job_id: jobId, chunk_index: chunkIndex, kind: 'video',
+                                       worker_id: currentWorkerId, status: 'processing',
+                                       progress: 0, version: WEB_WORKER_VERSION })
+            }).catch(() => {});
+        }, 15000);
+        return () => clearInterval(id);
+    }
+
+    function runChunkInWorker(chunk) {
+        return new Promise((resolve, reject) => {
+            if (!worker) { reject(new Error("Worker not initialized")); return; }
+            const stopHb = startChunkHeartbeat(chunk.job_id, chunk.chunk_index);
+            worker.onmessage = (e) => {
+                const msg = e.data;
+                if (msg.type === 'log') log(msg.msg, msg.level);
+                else if (msg.type === 'chunk_done' || msg.type === 'chunk_stale') { stopHb(); resolve(); }
+                else if (msg.type === 'chunk_error') { stopHb(); reject(new Error(msg.msg)); }
+            };
+            worker.onerror = (e) => { stopHb(); worker = null; reject(new Error("Worker Crashed: " + e.message)); };
+            worker.postMessage({type: 'run_chunk', chunk: chunk});
+        });
     }
 
     async function initWorker() {
@@ -334,9 +378,30 @@
 
         while (isRunning) {
             try {
-                // A. GET JOB — must send the version param or the manager's
-                // MIN_CLIENT_VERSION gate returns "Update Required". max_size_mb
-                // keeps the browser from being handed a file too big for wasm.
+                // A. CHUNK FIRST — take a slice of a large video via a pre-cut
+                // segment (video_only: browsers can't do the whole-file audio
+                // chunk). This is how browser nodes help on multi-GB sources.
+                const cres = await fetch(`/get_chunk?video_only=1&max_size_mb=${currentMaxSizeMb}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
+                if (cres.status === 200) {
+                    const cdata = await cres.json();
+                    if (cdata.status === 'ok' && cdata.chunk) {
+                        const ch = cdata.chunk;
+                        ch.worker_id = currentWorkerId;
+                        ch.wallet = currentWallet;
+                        ch.token = WORKER_TOKEN;
+                        currentChunk = { job_id: ch.job_id, chunk_index: ch.chunk_index };
+                        log(`CHUNK ${ch.chunk_index} of ${ch.filename}`, 'sys');
+                        await runChunkInWorker(ch);
+                        currentChunk = null;
+                        log("Chunk complete.", 'succ');
+                        continue;
+                    }
+                    if (cdata.status === 'retry') { await sleep((cdata.wait || 3) * 1000); continue; }
+                    // status 'empty' / chunking disabled → fall through to /get_job
+                }
+
+                // B. GET JOB (whole small files) — must send the version param or
+                // the manager's MIN_CLIENT_VERSION gate returns "Update Required".
                 const res = await fetch(`/get_job?max_size_mb=${currentMaxSizeMb}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
                 const data = await res.json();
 
@@ -366,7 +431,7 @@
                     await runJobInWorker(job);
                     currentJobId = null;
                     log("Job Cycle Complete.", 'succ');
-                    
+
                     // Optional: Restart worker every few jobs to clear fragmentation?
                     // For now, let's keep it running unless it crashes.
                 }

--- a/templates/web_worker.html
+++ b/templates/web_worker.html
@@ -217,9 +217,13 @@
     let isRunning = false;
     let worker = null;
     let currentWorkerId = "";
-    
+    let currentJobId = null;   // the job this node is actively encoding, for stop-time release
+
+    // Must be >= manager MIN_CLIENT_VERSION or /get_job returns "Update Required".
+    const WEB_WORKER_VERSION = "3.3.0";
+
     // Track if worker is ready (module initialized)
-    let isWorkerReady = false; 
+    let isWorkerReady = false;
 
     async function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
@@ -233,6 +237,20 @@
     function stopLoop() {
         isRunning = false;
         log("STOP command received. Finishing current job...", 'err');
+        // Release the in-flight job so it doesn't sit 'processing' until the
+        // manager's ~10-min stale sweep before another worker can take it.
+        if (currentJobId) {
+            const tok = new URLSearchParams(location.search).get('token');
+            try {
+                fetch('/report_status' + (tok ? ('?token=' + encodeURIComponent(tok)) : ''), {
+                    method: 'POST', headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ job_id: currentJobId, worker_id: currentWorkerId,
+                                           status: 'failed', error: 'Browser worker stopped',
+                                           version: WEB_WORKER_VERSION })
+                });
+            } catch (e) { /* best effort */ }
+            currentJobId = null;
+        }
         if (worker) {
             worker.terminate();
             worker = null;
@@ -288,16 +306,28 @@
         
         log(`Worker [${currentWorkerId}] Started. Polling for jobs...`, 'succ');
 
+        // Optional worker token: supply via ?token=... in the page URL when the
+        // manager enforces REQUIRE_WORKER_TOKEN. Kept out of the page source so
+        // the shared secret isn't baked into a public asset.
+        const _urlToken = new URLSearchParams(location.search).get('token');
+        const _authQS = _urlToken ? ('&token=' + encodeURIComponent(_urlToken)) : '';
+
         while (isRunning) {
             try {
-                // A. GET JOB
-                // Request max 256MB initially to be safe? 
-                // The worker has 1GB heap, but overhead matters. 
-                // Let's try 512MB again, hoping separate thread helps.
-                const res = await fetch('/get_job?max_size_mb=512');
+                // A. GET JOB — must send the version param or the manager's
+                // MIN_CLIENT_VERSION gate returns "Update Required".
+                const res = await fetch(`/get_job?max_size_mb=512&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
                 const data = await res.json();
 
+                if (res.status === 401) {
+                    log("Manager requires a worker token. Append ?token=YOUR_SECRET to this page's URL.", 'err');
+                    await sleep(15000);
+                    continue;
+                }
+
                 if (data.status === 'empty') {
+                    // Distinguish a real empty queue from a version rejection.
+                    if (data.message) log("Manager: " + data.message, 'err');
                     await sleep(10000);
                     continue;
                 }
@@ -305,11 +335,13 @@
                 if (data.status === 'ok') {
                     const job = data.job;
                     job.worker_id = currentWorkerId;
-                    
+                    currentJobId = job.id;
+
                     log(`STARTING JOB: ${job.filename} (${job.id})`, 'sys');
 
                     // Run in worker and wait
                     await runJobInWorker(job);
+                    currentJobId = null;
                     log("Job Cycle Complete.", 'succ');
                     
                     // Optional: Restart worker every few jobs to clear fragmentation?

--- a/templates/web_worker.html
+++ b/templates/web_worker.html
@@ -184,7 +184,7 @@
     <div class="dashboard-container">
         <div class="header-container">
             <div class="header-title-group">
-                <a href="/dashboard" class="back-link">&lt;&lt; BACK TO DASHBOARD</a>
+                <a href="/" class="back-link">&lt;&lt; BACK TO DASHBOARD</a>
                 <h1>// BROWSER_NODE_CONTROLLER</h1>
             </div>
         </div>
@@ -200,6 +200,19 @@
                     <label>WORKER_NAME:</label>
                     <input type="text" id="workerName" value="WebNode" style="width: 200px;">
                 </div>
+                <div>
+                    <label>WALLET (optional):</label>
+                    <input type="text" id="wallet" value="" placeholder="FractumCoin address" style="width: 220px;">
+                </div>
+                <div>
+                    <label title="Browser encoding is memory-limited. Larger files may crash the tab.">MAX SOURCE MB:</label>
+                    <input type="text" id="maxSizeMb" value="150" style="width: 80px;">
+                </div>
+            </div>
+            <div style="color: var(--text-dim); font-size: 0.8em; margin-bottom: 15px;">
+                In-browser AV1 encoding runs a full FFmpeg (SVT-AV1) in WebAssembly. It only
+                takes small source files (the manager filters by MAX SOURCE MB) and is slower
+                than a native worker. Keep this tab focused for best performance.
             </div>
             <div>
                 <button id="btnStart" class="btn-control" onclick="startLoop()">[ EXECUTE ]</button>
@@ -222,6 +235,12 @@
     // Must be >= manager MIN_CLIENT_VERSION or /get_job returns "Update Required".
     const WEB_WORKER_VERSION = "3.3.0";
 
+    // Worker token: injected by the manager (/web) so the page authenticates
+    // out of the box; ?token= in the URL overrides. Empty only if the manager
+    // couldn't inject it (e.g. page opened as a static file).
+    const WORKER_TOKEN = (new URLSearchParams(location.search).get('token'))
+                         || {{ worker_token | tojson }};
+
     // Track if worker is ready (module initialized)
     let isWorkerReady = false;
 
@@ -240,9 +259,8 @@
         // Release the in-flight job so it doesn't sit 'processing' until the
         // manager's ~10-min stale sweep before another worker can take it.
         if (currentJobId) {
-            const tok = new URLSearchParams(location.search).get('token');
             try {
-                fetch('/report_status' + (tok ? ('?token=' + encodeURIComponent(tok)) : ''), {
+                fetch('/report_status' + (WORKER_TOKEN ? ('?token=' + encodeURIComponent(WORKER_TOKEN)) : ''), {
                     method: 'POST', headers: {'Content-Type': 'application/json'},
                     body: JSON.stringify({ job_id: currentJobId, worker_id: currentWorkerId,
                                            status: 'failed', error: 'Browser worker stopped',
@@ -288,10 +306,16 @@
         });
     }
 
+    let currentWallet = "";
+    let currentMaxSizeMb = 150;
+
     async function startLoop() {
         const user = document.getElementById('username').value.trim() || "Anonymous";
         const node = document.getElementById('workerName').value.trim() || "WebNode";
-        const runId = Math.floor(Date.now() / 1000); 
+        currentWallet = document.getElementById('wallet').value.trim();
+        const mb = parseInt(document.getElementById('maxSizeMb').value, 10);
+        currentMaxSizeMb = (Number.isFinite(mb) && mb > 0) ? mb : 150;
+        const runId = Math.floor(Date.now() / 1000);
         currentWorkerId = `${user}-${node}-${runId}-1`;
 
         try {
@@ -306,21 +330,18 @@
         
         log(`Worker [${currentWorkerId}] Started. Polling for jobs...`, 'succ');
 
-        // Optional worker token: supply via ?token=... in the page URL when the
-        // manager enforces REQUIRE_WORKER_TOKEN. Kept out of the page source so
-        // the shared secret isn't baked into a public asset.
-        const _urlToken = new URLSearchParams(location.search).get('token');
-        const _authQS = _urlToken ? ('&token=' + encodeURIComponent(_urlToken)) : '';
+        const _authQS = WORKER_TOKEN ? ('&token=' + encodeURIComponent(WORKER_TOKEN)) : '';
 
         while (isRunning) {
             try {
                 // A. GET JOB — must send the version param or the manager's
-                // MIN_CLIENT_VERSION gate returns "Update Required".
-                const res = await fetch(`/get_job?max_size_mb=512&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
+                // MIN_CLIENT_VERSION gate returns "Update Required". max_size_mb
+                // keeps the browser from being handed a file too big for wasm.
+                const res = await fetch(`/get_job?max_size_mb=${currentMaxSizeMb}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
                 const data = await res.json();
 
                 if (res.status === 401) {
-                    log("Manager requires a worker token. Append ?token=YOUR_SECRET to this page's URL.", 'err');
+                    log("Manager rejected the worker token. Open this page via the manager's /web URL, or append ?token=YOUR_SECRET.", 'err');
                     await sleep(15000);
                     continue;
                 }
@@ -335,6 +356,8 @@
                 if (data.status === 'ok') {
                     const job = data.job;
                     job.worker_id = currentWorkerId;
+                    job.wallet = currentWallet;
+                    job.token = WORKER_TOKEN;
                     currentJobId = job.id;
 
                     log(`STARTING JOB: ${job.filename} (${job.id})`, 'sys');

--- a/wasm-build/Dockerfile
+++ b/wasm-build/Dockerfile
@@ -1,0 +1,125 @@
+# =============================================================================
+# Reproducible FFmpeg -> WebAssembly build for the Fractum browser worker.
+#
+# Produces static/ffmpeg.js, ffmpeg.wasm, ffmpeg.worker.js with:
+#   - SVT-AV1 (libsvtav1) video encoding
+#   - libopus audio encoding
+#   - pthreads (needs COOP/COEP on the manager, already set)
+#
+# This mirrors the ORIGINAL build's FFmpeg configure line (recovered from the
+# shipped ffmpeg.wasm, which was FFmpeg 6.1 / Lavc60.31.102) and bumps the
+# components to current releases. Pin the ARG versions below to control it.
+#
+# Build:   docker build -t fractum-ffwasm ./wasm-build
+# Extract: docker run --rm -v "$PWD/static:/out" fractum-ffwasm cp -a \
+#            /build/dist/ffmpeg.js /build/dist/ffmpeg.wasm /build/dist/ffmpeg.worker.js /out/
+#
+# NOTE: This recipe has NOT been executed in the environment it was written in.
+# The two steps most likely to need a tweak are called out in wasm-build/README.md
+# (SVT-AV1's wasm CMake, and the Emscripten pthread output naming).
+# =============================================================================
+
+# Emscripten toolchain. 3.1.51 is a known-good era that still emits a separate
+# <name>.worker.js for -pthread builds, which is what web_node.js importScripts.
+# If you bump this and the separate .worker.js disappears, see the README.
+ARG EMSDK_VERSION=3.1.51
+FROM emscripten/emsdk:${EMSDK_VERSION}
+
+# Component versions — bump these to rebuild with newer AV1 development.
+ARG FFMPEG_VERSION=n7.1
+ARG SVTAV1_VERSION=v2.3.0
+ARG OPUS_VERSION=v1.5.2
+
+ENV BUILD=/build
+ENV PREFIX=/build/prefix
+# -pthread everywhere; -fno-stack-protector avoids needing the old dummy_ssp.o
+# stub the original build carried in its ldflags.
+ENV CFLAGS="-O2 -pthread -fno-stack-protector -I${PREFIX}/include"
+ENV CXXFLAGS="${CFLAGS}"
+ENV LDFLAGS="-O2 -pthread -L${PREFIX}/lib"
+ENV PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
+
+RUN mkdir -p ${BUILD} ${PREFIX}
+WORKDIR ${BUILD}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git cmake ninja-build build-essential pkg-config yasm && \
+    rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# 1. libopus  (audio encoder)
+# -----------------------------------------------------------------------------
+RUN git clone --depth 1 --branch ${OPUS_VERSION} https://github.com/xiph/opus.git && \
+    cd opus && ./autogen.sh && \
+    emconfigure ./configure --prefix=${PREFIX} --disable-shared --enable-static \
+      --disable-doc --disable-extra-programs \
+      --disable-asm --disable-rtcd --disable-intrinsics && \
+    emmake make -j"$(nproc)" && emmake make install
+
+# -----------------------------------------------------------------------------
+# 2. SVT-AV1  (video encoder)  <-- the trickiest part; see README if it fails.
+#    On a non-x86 toolchain SVT-AV1's CMake compiles its C-only path (no asm),
+#    which is what we want for wasm. Apps/tests are off; threads use pthreads.
+# -----------------------------------------------------------------------------
+RUN git clone --depth 1 --branch ${SVTAV1_VERSION} https://gitlab.com/AOMediaCodec/SVT-AV1.git && \
+    cd SVT-AV1 && mkdir b && cd b && \
+    emcmake cmake .. -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_APPS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+      -DCMAKE_C_FLAGS="${CFLAGS}" \
+      -DCMAKE_CXX_FLAGS="${CXXFLAGS}" && \
+    ninja -j"$(nproc)" && ninja install
+
+# -----------------------------------------------------------------------------
+# 3. FFmpeg  (mirrors the original configure line, components bumped)
+# -----------------------------------------------------------------------------
+RUN git clone --depth 1 --branch ${FFMPEG_VERSION} https://git.ffmpeg.org/ffmpeg.git && \
+    cd ffmpeg && \
+    emconfigure ./configure \
+      --prefix=${PREFIX} \
+      --target-os=none \
+      --arch=x86_32 \
+      --enable-cross-compile \
+      --disable-x86asm --disable-inline-asm \
+      --disable-stripping \
+      --enable-ffmpeg --disable-ffprobe --disable-ffplay --disable-doc \
+      --disable-network --disable-debug --disable-autodetect \
+      --disable-shared --enable-static \
+      --enable-gpl \
+      --enable-libsvtav1 --enable-encoder=libsvtav1 \
+      --enable-libopus  --enable-encoder=libopus --enable-decoder=opus \
+      --nm=emnm --ar=emar --ranlib=emranlib --cc=emcc --cxx=em++ \
+      --extra-cflags="${CFLAGS}" --extra-cxxflags="${CXXFLAGS}" --extra-ldflags="${LDFLAGS}" \
+      --pkg-config=pkg-config --pkg-config-flags="--static" && \
+    emmake make -j"$(nproc)"
+
+# -----------------------------------------------------------------------------
+# 4. Final Emscripten link into the browser-loadable ffmpeg.js/.wasm/.worker.js
+#    ffmpeg's own build produces the object; we relink with the JS-runtime flags
+#    web_node.js depends on (global Module, callMain, FS, pthreads, growth).
+# -----------------------------------------------------------------------------
+RUN mkdir -p ${BUILD}/dist && cd ${BUILD}/ffmpeg && \
+    emcc -O2 -pthread \
+      -o ${BUILD}/dist/ffmpeg.js \
+      fftools/*.o libavcodec/*.a libavfilter/*.a libavformat/*.a \
+      libavutil/*.a libswresample/*.a libswscale/*.a \
+      ${PREFIX}/lib/libSvtAv1Enc.a ${PREFIX}/lib/libopus.a \
+      -sUSE_PTHREADS=1 \
+      -sPTHREAD_POOL_SIZE=8 \
+      -sPROXY_TO_PTHREAD=1 \
+      -sALLOW_MEMORY_GROWTH=1 \
+      -sMAXIMUM_MEMORY=2gb \
+      -sINITIAL_MEMORY=64mb \
+      -sEXPORTED_RUNTIME_METHODS=callMain,FS \
+      -sINVOKE_RUN=0 \
+      -sEXIT_RUNTIME=0 \
+      -sFORCE_FILESYSTEM=1 \
+      -sMODULARIZE=0 \
+      || (echo '*** Final link failed — see README "Linking" section ***' && false)
+
+# The three artifacts to copy into ../static/
+#   /build/dist/ffmpeg.js  /build/dist/ffmpeg.wasm  /build/dist/ffmpeg.worker.js
+WORKDIR ${BUILD}/dist

--- a/wasm-build/README.md
+++ b/wasm-build/README.md
@@ -1,0 +1,83 @@
+# Rebuilding the browser worker's FFmpeg WebAssembly
+
+The in-browser worker (`/web`) runs a custom FFmpeg compiled to WebAssembly with
+**SVT-AV1** and **libopus**. This directory rebuilds it reproducibly with Docker,
+so you can pick up newer AV1 development without remembering the original steps.
+
+## What the original build was
+
+Recovered from the shipped `static/ffmpeg.wasm`:
+
+- **FFmpeg 6.1** (`Lavc60.31.102`)
+- Emscripten toolchain, `--arch=x86_32` (32-bit), `-pthread`
+- `--enable-gpl --enable-libsvtav1`, libopus statically linked
+- `--disable-network --disable-ffprobe --disable-ffplay --disable-doc`
+- Output: `ffmpeg.js` + `ffmpeg.wasm` + `ffmpeg.worker.js` (classic pthread build,
+  non-modularized — `web_node.js` does `importScripts('ffmpeg.js')` and uses the
+  global `self.Module`).
+
+The `Dockerfile` here reproduces that configuration and bumps the components to
+current releases (FFmpeg 7.1, SVT-AV1 2.3.0, opus 1.5.2 by default — change the
+`ARG` lines to pin whatever you want).
+
+## Build it
+
+```bash
+# from the repo root
+docker build -t fractum-ffwasm ./wasm-build
+
+# copy the three artifacts into static/ (overwrites the old wasm)
+docker run --rm -v "$PWD/static:/out" fractum-ffwasm \
+  sh -c 'cp -a /build/dist/ffmpeg.js /build/dist/ffmpeg.wasm /build/dist/ffmpeg.worker.js /out/'
+```
+
+Then hard-refresh `/web` (the page already cache-busts the worker URL) and run a
+small test file through it.
+
+## Bumping versions
+
+Edit the `ARG` lines at the top of the `Dockerfile`:
+
+```dockerfile
+ARG FFMPEG_VERSION=n7.1
+ARG SVTAV1_VERSION=v2.3.0
+ARG OPUS_VERSION=v1.5.2
+ARG EMSDK_VERSION=3.1.51
+```
+
+SVT-AV1 has moved a lot since your original build — newer releases encode faster
+at the same quality, so a bump is worthwhile.
+
+## Two spots most likely to need a tweak (be ready to iterate)
+
+This recipe reconstructs your exact FFmpeg configure line (that part is known-good
+from your binary), but two steps depend on toolchain/library specifics that shift
+between versions. If a `docker build` fails, it's almost certainly one of these:
+
+1. **SVT-AV1's wasm CMake (step 2).** SVT-AV1 is heavily x86-optimized; on the
+   Emscripten toolchain its CMake should fall back to the portable C path
+   automatically (no asm). If it tries to use x86 intrinsics or fails detecting
+   the target, pass `-DCMAKE_SYSTEM_PROCESSOR=generic` and/or the release's
+   documented "C-only" switch. SVT-AV1 also leans on threads heavily — keep the
+   Emscripten `PTHREAD_POOL_SIZE` (step 4) at least as large as the encoder's
+   thread count (the browser worker already caps SVT threads via
+   `-svtav1-params lp=1`, so a small pool is fine).
+
+2. **Emscripten pthread output naming (steps 1/4).** `web_node.js` expects a
+   separate `ffmpeg.worker.js`. Emscripten versions around **3.1.51** emit that
+   file for `-pthread`; some **newer** versions changed how the pthread worker is
+   delivered and may not emit a standalone `.worker.js`. If yours doesn't:
+   either pin `EMSDK_VERSION` back to a version that does, **or** update
+   `web_node.js` (the `mainScriptUrlOrBlob` / worker bootstrap) to the new model.
+   Nothing else in the app cares which you choose.
+
+## Memory reality (why this only takes small files)
+
+The build is 32-bit (`--arch=x86_32`), so the whole process is capped near 2 GB
+usable, and `--disable-network` means the page must load the entire source into
+memory before encoding. That's why the browser worker is limited to small files
+(the `/web` page's "MAX SOURCE MB" control, default 150). Making it handle the
+multi-GB sources would require **manager-side segmentation** — serving small,
+independently-decodable pieces to the browser rather than whole files. See the
+project discussion / ask the maintainer before building that; it's an additive
+manager feature, not a wasm rebuild.

--- a/wasm-build/README.md
+++ b/wasm-build/README.md
@@ -74,10 +74,13 @@ between versions. If a `docker build` fails, it's almost certainly one of these:
 ## Memory reality (why this only takes small files)
 
 The build is 32-bit (`--arch=x86_32`), so the whole process is capped near 2 GB
-usable, and `--disable-network` means the page must load the entire source into
-memory before encoding. That's why the browser worker is limited to small files
-(the `/web` page's "MAX SOURCE MB" control, default 150). Making it handle the
-multi-GB sources would require **manager-side segmentation** — serving small,
-independently-decodable pieces to the browser rather than whole files. See the
-project discussion / ask the maintainer before building that; it's an additive
-manager feature, not a wasm rebuild.
+usable, and `--disable-network` means the page must load its input into memory
+before encoding.
+
+For **whole-file** browser jobs that limits you to small sources (the `/web`
+page's "MAX SOURCE MB", default 150). For **large** sources, the browser worker
+uses **server-side segmentation** (implemented): it takes one chunk at a time
+and downloads only that chunk's small pre-cut segment via `/download_segment`,
+so it never loads a multi-GB file. See the "Server-side segmentation" section in
+the main README. That means a newer wasm doesn't need memory64 to help on big
+files — segmentation already keeps each piece small.

--- a/worker_template.py
+++ b/worker_template.py
@@ -113,7 +113,7 @@ except ImportError as _e:
 DEFAULT_MANAGER_URL = "https://encode.fractumseraph.net/"
 DEFAULT_USERNAME = "Anonymous"
 DEFAULT_WORKERNAME = f"Node-{int(time.time())}"
-WORKER_VERSION = "3.2.0"
+WORKER_VERSION = "3.3.0"
 WORKER_SECRET = os.environ.get("WORKER_SECRET", "DefaultInsecureSecret")
 
 SHUTDOWN_EVENT = threading.Event()
@@ -1669,6 +1669,11 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
         if PAUSE_REQUESTED:
              time.sleep(1); continue
 
+        # Reset per-iteration job id so the catch-all handler below can't
+        # mis-report a failure against the PREVIOUS (already-completed) job
+        # when an error happens before a new job is assigned.
+        job_id = None
+
         try:
             if quota_tracker and quota_tracker.check_cap():
                 wait_sec = quota_tracker.get_wait_time()
@@ -1984,7 +1989,23 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                     elif rc.status_code == 200:
                         cdata = rc.json()
                         if cdata.get("status") == "ok" and cdata.get("chunk"):
-                            process_chunk(cdata["chunk"])
+                            _ch = cdata["chunk"]
+                            try:
+                                process_chunk(_ch)
+                            except Exception as _ce:
+                                # Release the chunk immediately instead of letting
+                                # it sit 'processing' until the 30-min stale sweep
+                                # (which would stall the whole split-video pipeline
+                                # the other threads are converged on).
+                                log(worker_id, f"Chunk processing crashed: {_ce}", "ERROR")
+                                try:
+                                    requests.post(f"{manager_url}/report_chunk", json={
+                                        "job_id": _ch.get("job_id"), "chunk_index": _ch.get("chunk_index"),
+                                        "kind": _ch.get("kind", "video"), "worker_id": worker_id,
+                                        "status": "failed", "error": str(_ce)[:512],
+                                        "version": WORKER_VERSION,
+                                    }, headers=get_auth_headers(), timeout=10)
+                                except Exception: pass
                             continue
                         elif cdata.get("status") == "retry":
                             # Manager is splitting a video right now — wait for
@@ -2036,7 +2057,13 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                 if d is not None:
                     d.update({"file": job['filename'], "phase": "Probe", "pct": 0, "job_start": time.time()})
 
-                local_dst = os.path.join(temp_dir, f"encoded{ENCODING_CONFIG['OUTPUT_EXT']}")
+                # Per-job output filename so a leftover resume checkpoint can
+                # never point at a DIFFERENT job's partial data. Previously every
+                # job in a thread wrote to the same encoded.mp4, so a stale
+                # checkpoint for job A could be resumed against job B's bytes and
+                # uploaded as A — silent content corruption.
+                _dst_safe_id = re.sub(r'[^a-zA-Z0-9_-]', '_', str(job_id))[:80]
+                local_dst = os.path.join(temp_dir, f"encoded_{_dst_safe_id}{ENCODING_CONFIG['OUTPUT_EXT']}")
 
                 # FFmpeg auth header string (format required by libavformat HTTP demuxer)
                 ffmpeg_http_headers = f"X-Worker-Token: {WORKER_SECRET}\r\n"
@@ -2470,7 +2497,8 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
             err_tb = traceback.format_exc()
             log(worker_id, f"Error: {err_str}", "CRITICAL")
             try:
-                if 'job_id' in locals():
+                # Only report against a job actually assigned this iteration.
+                if job_id:
                     post_status("failed", error_msg=err_str)
                     report_error(job_id, "exception", err_str, err_tb)
             except: pass
@@ -2791,7 +2819,18 @@ def run_worker(args):
                 try: _input_src.close()
                 except: pass
 
-    if UPDATE_AVAILABLE: apply_update(manager_url)
+    if UPDATE_AVAILABLE:
+        # Before re-exec'ing into the new version, make sure every worker
+        # thread has actually stopped and its ffmpeg child is dead. Otherwise
+        # a sibling thread's ffmpeg (started with start_new_session=True)
+        # survives the execv and keeps writing its output file while the
+        # restarted worker reuses the same temp dir — a corrupt upload.
+        SHUTDOWN_EVENT.set()
+        for t in threads:
+            t.join(timeout=60)
+        kill_processes()
+        time.sleep(1)  # let the OS reap terminated ffmpeg children
+        apply_update(manager_url)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary

Several coupled bodies of work on one branch. Encode targets unchanged throughout.

1. **Full-codebase audit fixes** — security, correctness, scalability (five parallel reviewers).
2. **The in-browser AV1 worker now works** — it depends on the audit's auth change, so it ships together.
3. **Server-side segmentation** — browser workers can now chunk multi-GB files.
4. **Reproducible WASM build recipe** (`wasm-build/`) so the FFmpeg→WebAssembly bundle can be rebuilt with newer AV1.

---

## Part 1 — Audit hardening
- **Auth**: `requires_worker_auth` no longer waves through tokenless requests (`REQUIRE_WORKER_TOKEN`, default on, constant-time compare). CSRF host check fixed.
- **Correctness**: `report_status` ownership/terminal guards; `failed` jobs auto-requeue; `upload_result` rejects stale/split jobs; `_assemble_job` commit guarded; RAM-mode restart no longer rolls back; scoreboard time windows use local time.
- **Scalability (~6,600 jobs)**: added indexes; `get_series_list` cached; `system_logs` pruned; `/api/all_jobs` bounded.
- **Worker**: auto-update no longer orphans encoders; per-job temp names; `process_chunk` releases chunks on error; no stale-job misreport.
- **Frontend**: `permanently_failed` visible; admin buttons use `data-*`+delegation (no apostrophe injection).

## Part 2 — Working browser AV1 worker
The bundled `ffmpeg.wasm` is a purpose-built FFmpeg with `--enable-libsvtav1` + Opus — browser AV1 was always possible, just broken/unwired.
- Served at `/web` (+ `/node`), linked from the dashboard; token injected server-side so it authenticates despite `REQUIRE_WORKER_TOKEN`.
- Fixed the syntax error that stopped `web_node.js` parsing; removed duplicate `-svtav1-params`; explicit `-map`/`-sn` (no ffprobe in the build); version param + "Update Required" handling; wallet field.
- OOM guard: "MAX SOURCE MB" (default 150) drives `get_job`'s size filter for whole-file jobs.

## Part 3 — Server-side segmentation (browser workers on big files)
- `/download_segment`: stream-copies a small keyframe-aligned segment for one video chunk (`-copyts` + `-to`), returns the exact inner-seek **lead** + duration in headers.
- `/get_chunk?video_only=1`: browser nodes get video chunks only (native worker does the audio); each carries a `segment_url`.
- `web_node.js` gains a chunk path (fetch segment → seek by lead → encode `[start,start+dur]` → `/upload_chunk`); `web_worker.html` polls chunks first, heartbeats during the encode, and releases the chunk on stop.
- Same per-job chunk plan as desktop, so boundaries tile identically. A browser only downloads ~one chunk's worth of data, never the whole multi-GB source.

## Part 4 — WASM build recipe (`wasm-build/`)
Docker recipe (opus → SVT-AV1 → FFmpeg → link) reconstructing the original configure line (recovered from the shipped wasm: FFmpeg 6.1), bumped to current releases via `ARG`s. README documents build/extract and the two toolchain-sensitive steps.

## Testing
- Auth 401/200 matrix; `report_status` guards; failed-job auto-requeue; whole-file browser upload path (token header + wallet → completed + earning).
- **Segmentation end-to-end**: browser-simulated workers encoded all video chunks from segments (per-keyframe leads 0.0/18.25/4.25s), native worker did the audio, assembly produced a frame-exact result (av1/480 + opus, 1500/1500 frames, 150.02s, clean decode), earnings correct.
- `py_compile` + `node --check` clean.
- **Not runnable in this environment**: live in-browser wasm execution and the Docker wasm build (no browser / no docker daemon). Their prerequisites were each verified natively (libsvtav1 present in the wasm, exact encode args, segment/lead math, HTTP paths, COOP/COEP + `application/wasm`).

## Deferred
Positional `--series-id` remap; minor worker edge cases (paused-heartbeat, multi-process quota, non-TUI second-Ctrl+C); wasm memory64 (not needed — segmentation keeps pieces small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm