### PR TITLE
Fix browser worker NetworkError on whole-file (remote) sources

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -1430,8 +1430,67 @@ python3 worker.py --username "{u}" --workername "{w}" --jobs {j} --manager "{SER
     return Response(script, mimetype='text/x-shellscript')
 
 @app.route('/download_source/<path:filename>')
-def download_source(filename): 
+def download_source(filename):
     return send_from_directory(SOURCE_DIRECTORY, filename, as_attachment=True)
+
+@app.route('/download_media')
+@requires_worker_auth
+def download_media():
+    """Same-origin source download for the browser worker. The /web page is
+    cross-origin isolated (COEP: require-corp), so it CANNOT fetch a remote
+    source directly — the browser blocks it with a NetworkError. This proxies
+    the source through the manager (which has no such restriction): local files
+    are served from disk, remote files are streamed through. Only used for
+    whole-file browser jobs (chunk workers use /download_segment)."""
+    job_id = (request.args.get('job_id') or '').strip()
+    if not job_id:
+        return abort(400)
+    with db_lock:
+        conn = db_handler.get_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            c = conn.cursor()
+            c.execute("SELECT source_type, source_url FROM jobs WHERE id=?", (job_id,))
+            row = c.fetchone()
+        finally:
+            conn.close()
+    if row is None:
+        return abort(404)
+
+    if row['source_type'] != 'remote':
+        # Local file: reuse the safe directory sender (blocks path traversal).
+        return send_from_directory(SOURCE_DIRECTORY, job_id, as_attachment=True)
+
+    # Remote: stream it through the manager so the browser sees a same-origin
+    # response. The manager fetches server-side (no COEP), forwarding the token.
+    remote_url = build_download_url(job_id, 'remote', row['source_url'])
+    if not remote_url:
+        return abort(404)
+    try:
+        upstream = requests.get(remote_url,
+                                headers={'User-Agent': 'FractumManager/1.0',
+                                         'X-Worker-Token': WORKER_SECRET},
+                                stream=True, timeout=60)
+    except requests.exceptions.RequestException as e:
+        log_event("WARN", f"download_media proxy failed: {e}", job_id)
+        return abort(502)
+    if upstream.status_code != 200:
+        upstream.close()
+        return abort(upstream.status_code if upstream.status_code >= 400 else 502)
+
+    from flask import stream_with_context
+    def _gen():
+        try:
+            for block in upstream.iter_content(chunk_size=1024 * 256):
+                yield block
+        finally:
+            upstream.close()
+    headers = {}
+    if upstream.headers.get('Content-Length'):
+        headers['Content-Length'] = upstream.headers['Content-Length']
+    return Response(stream_with_context(_gen()),
+                    content_type=upstream.headers.get('Content-Type', 'application/octet-stream'),
+                    headers=headers)
 
 @app.route('/get_job', methods=['GET'])
 @requires_worker_auth

--- a/static/web_node.js
+++ b/static/web_node.js
@@ -223,9 +223,14 @@ async function processJob(job) {
     postMessage({type: 'log', level: 'sys', msg: `Worker processing: ${job.filename}`});
 
     try {
-        // 1. Download
-        postMessage({type: 'log', level: 'sys', msg: "Downloading source..."});
-        const resp = await fetch(job.download_url);
+        // 1. Download — ALWAYS via the manager (same-origin). The /web page is
+        // cross-origin isolated (COEP: require-corp), so fetching a remote
+        // source directly (job.download_url can point off-origin) fails with a
+        // NetworkError. /download_media proxies remote sources and serves local
+        // ones, so the browser always sees a same-origin response.
+        postMessage({type: 'log', level: 'sys', msg: "Downloading source (via manager)..."});
+        const mediaUrl = '/download_media?job_id=' + encodeURIComponent(job.id);
+        const resp = await fetch(mediaUrl, { headers: job.token ? { 'X-Worker-Token': job.token } : {} });
         if (!resp.ok) throw new Error("Download failed: " + resp.status);
         
         const buf = await resp.arrayBuffer();


### PR DESCRIPTION
## Summary

Fixes the `NetworkError when attempting to fetch resource` you hit on `/web` for whole-file jobs.

**Cause:** the `/web` page is cross-origin isolated (`COEP: require-corp`, required so the WASM can use threads). Under that policy the browser **cannot fetch a source from a different origin**. Whole-file jobs were handed `job.download_url`, which for **remote** sources points straight at the off-origin source server (your `treasure` host) — so every browser whole-file download failed. (Chunk workers were unaffected; they already fetch same-origin via `/download_segment`, where the manager does the remote fetch server-side.)

Those files in your log (Luxo Jr, Friskies Commercials, etc.) are short, so they aren't chunked — they came through the whole-file path and hit exactly this.

**Fix:** a same-origin `/download_media?job_id=` endpoint (worker-auth) that serves local sources from disk and **streams remote sources through the manager** (which has no COEP restriction). The browser's whole-file path now always downloads via this proxy with the worker token, so the response is always same-origin.

## Testing
- `/download_media` returns a local file and a proxied remote file **byte-identically**; missing token → 401.
- Full browser whole-file job (`get_job` → `/download_media` → encode → `/upload_result`) completes and marks the job done.
- `py_compile` + `node --check` clean.
- (Live in-browser run still not executable here — but this reproduces and removes the exact cross-origin fetch that failed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_