### PR TITLE
Stop browser worker crashing on long chunks (cap chunk length per worker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,9 @@ Browser workers can't range-stream a multi-GB source (32-bit WebAssembly, and th
 - It fetches that chunk's bytes from **`/download_segment`**, which stream-copies (`-c copy`, no re-encode) just a small, keyframe-aligned segment covering the chunk's time range and returns it with `X-Segment-Lead` / `X-Segment-Duration` headers.
 - The browser seeks by the lead and encodes exactly `[start, start+dur]` — identical to what a native chunk worker produces — then uploads via `/upload_chunk`.
 - The whole-file **audio** chunk is skipped by browser nodes (`video_only`); a native worker encodes it. The manager assembles as usual.
+- **Memory limit:** a browser node advertises a **MAX CHUNK SEC** (default 120) and is only handed chunks at or under that length. Long chunks (e.g. 300s of 1080p) exhaust the 32-bit WebAssembly heap and trap it (`unreachable executed`), so this cap keeps browser encodes from crashing. Native workers take any length. For browser volunteers to get work, keep `CHUNK_DURATION_SEC` at or below their MAX CHUNK SEC.
 
-So a browser volunteer only ever downloads ~one chunk's worth of data (e.g. ~80 MB for a 5-min slice of a 2 GB file), never the whole source. Boundaries come from the single per-job chunk plan, so browser and desktop chunks tile identically.
+So a browser volunteer only ever downloads ~one chunk's worth of data (e.g. ~30 MB for a 2-min slice of a 2 GB file), never the whole source. Boundaries come from the single per-job chunk plan, so browser and desktop chunks tile identically.
 
 **Config** (`config.py`, both optional):
 

--- a/config.py.example
+++ b/config.py.example
@@ -73,7 +73,13 @@ CHUNKED_ENCODING = True
 
 # Target length of each video chunk in seconds (minimum 60).
 # Shorter = more parallelism, slightly more coordination overhead.
-CHUNK_DURATION_SEC = 300
+# NOTE for browser (WASM) workers: they can only take chunks short enough to
+# fit the 32-bit WebAssembly heap — a long chunk (e.g. 300s of 1080p) traps
+# the wasm ("unreachable executed"). Browser nodes advertise a MAX CHUNK SEC
+# (default 120) and are only handed chunks at or under it; native workers take
+# any length. If you want browser volunteers to help on big videos, keep this
+# at/below their MAX CHUNK SEC (120 is a safe starting point).
+CHUNK_DURATION_SEC = 120
 
 # ==============================================================================
 # RATE LIMITING

--- a/manager.py
+++ b/manager.py
@@ -688,11 +688,15 @@ def _split_claimed_job(job):
         finally:
             conn.close()
 
-def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=False):
+def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=False, max_chunk_sec=None):
     """Hand the oldest pending chunk to a worker. Prioritizes the earliest-started
     job so the swarm finishes one video before spilling into the next.
     video_only=True (browser workers) skips the whole-file audio chunk, which
-    they can't segment; a native worker encodes the audio track."""
+    they can't segment; a native worker encodes the audio track.
+    max_chunk_sec caps the chunk LENGTH a worker will accept — browser (wasm)
+    workers set this so they are never handed a chunk too long to hold in the
+    32-bit heap (which traps as 'unreachable executed'); native workers leave it
+    unset and take any length."""
     with db_lock:
         conn = db_handler.get_connection()
         conn.row_factory = sqlite3.Row
@@ -701,6 +705,12 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=Fals
             query_parts = ["c.status='pending'", "j.status='processing'", "COALESCE(j.chunked,0)=1"]
             if video_only:
                 query_parts.append("c.kind='video'")
+            if max_chunk_sec:
+                try:
+                    query_parts.append("c.duration_sec <= ?")
+                    params.append(float(max_chunk_sec))
+                except (TypeError, ValueError):
+                    pass
             if folder_filter:
                 query_parts.append("j.id LIKE ?")
                 params.append(f"{folder_filter}%")
@@ -1614,8 +1624,11 @@ def get_chunk():
     worker_id = sanitize_input(request.args.get('worker_id'))
     worker_version = sanitize_input(request.args.get('version'))
     # Browser workers pass video_only=1: they fetch a pre-cut segment per video
-    # chunk and can't handle the whole-file audio chunk.
+    # chunk and can't handle the whole-file audio chunk. max_chunk_sec caps the
+    # chunk length they'll accept so the 32-bit wasm doesn't OOM/trap on a long
+    # chunk; native workers omit it.
     video_only = request.args.get('video_only') in ('1', 'true', 'yes')
+    max_chunk_sec = request.args.get('max_chunk_sec')
 
     if is_worker_banned(worker_id):
         return jsonify({"status": "empty", "message": "Unauthorized"}), 403
@@ -1625,7 +1638,7 @@ def get_chunk():
     try:
         folder_filter = _resolve_folder_filter(series_id)
 
-        chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=video_only)
+        chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=video_only, max_chunk_sec=max_chunk_sec)
         if chunk is None:
             if SPLIT_LOCK.acquire(blocking=False):
                 # No pending chunks anywhere — split the next queued job.
@@ -1637,7 +1650,7 @@ def get_chunk():
                 try:
                     job = _claim_job_for_split(folder_filter, max_size_mb)
                     if job is not None and _split_claimed_job(job):
-                        chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=video_only)
+                        chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=video_only, max_chunk_sec=max_chunk_sec)
                 finally:
                     SPLIT_LOCK.release()
             else:

--- a/templates/web_worker.html
+++ b/templates/web_worker.html
@@ -208,6 +208,10 @@
                     <label title="Browser encoding is memory-limited. Larger files may crash the tab.">MAX SOURCE MB:</label>
                     <input type="text" id="maxSizeMb" value="150" style="width: 80px;">
                 </div>
+                <div>
+                    <label title="Longest chunk (seconds) this browser will accept. Long chunks can exhaust the 32-bit WASM memory and crash. Lower it if you see crashes.">MAX CHUNK SEC:</label>
+                    <input type="text" id="maxChunkSec" value="120" style="width: 80px;">
+                </div>
             </div>
             <div style="color: var(--text-dim); font-size: 0.8em; margin-bottom: 15px;">
                 In-browser AV1 encoding runs a full FFmpeg (SVT-AV1) in WebAssembly. It only
@@ -352,6 +356,7 @@
 
     let currentWallet = "";
     let currentMaxSizeMb = 150;
+    let currentMaxChunkSec = 120;
 
     async function startLoop() {
         const user = document.getElementById('username').value.trim() || "Anonymous";
@@ -359,6 +364,8 @@
         currentWallet = document.getElementById('wallet').value.trim();
         const mb = parseInt(document.getElementById('maxSizeMb').value, 10);
         currentMaxSizeMb = (Number.isFinite(mb) && mb > 0) ? mb : 150;
+        const mcs = parseInt(document.getElementById('maxChunkSec').value, 10);
+        currentMaxChunkSec = (Number.isFinite(mcs) && mcs > 0) ? mcs : 120;
         const runId = Math.floor(Date.now() / 1000);
         currentWorkerId = `${user}-${node}-${runId}-1`;
 
@@ -381,7 +388,7 @@
                 // A. CHUNK FIRST — take a slice of a large video via a pre-cut
                 // segment (video_only: browsers can't do the whole-file audio
                 // chunk). This is how browser nodes help on multi-GB sources.
-                const cres = await fetch(`/get_chunk?video_only=1&max_size_mb=${currentMaxSizeMb}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
+                const cres = await fetch(`/get_chunk?video_only=1&max_size_mb=${currentMaxSizeMb}&max_chunk_sec=${currentMaxChunkSec}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
                 if (cres.status === 200) {
                     const cdata = await cres.json();
                     if (cdata.status === 'ok' && cdata.chunk) {


### PR DESCRIPTION
## Summary

From your latest `/web` log: the browser worker crashed with `RuntimeError: unreachable executed` about a minute into encoding a **~289-second** 1080p→480p chunk at preset 2, then crash-looped onto the next chunk. That's the 32-bit WebAssembly heap being exhausted by a chunk that long.

**Fix:** let a browser only take chunks short enough to fit its memory.
- `/get_chunk` now accepts `max_chunk_sec`, and `_assign_pending_chunk` only hands a worker chunks at or under that length. Browser nodes advertise it (new **MAX CHUNK SEC** field on `/web`, default 120s); native workers omit it and still take any length. If no chunk fits, the browser idles / takes whole small files instead of crashing.
- Lowered the example `CHUNK_DURATION_SEC` to 120 and documented the browser memory limit, so browser volunteers actually get eligible chunks (with a 300s plan and a 120s cap they'd get none).

## Not a bug (from the same log)
The small segment sizes (≈800 KB for a 289s chunk) are **correct**, not truncation — "The Endless River" genuinely has a ~20 kbps video stream (near-static album visuals), confirmed by its own `BPS: 20688` metadata. The `-copyts` "Duration" ffmpeg prints is the segment's absolute end timestamp, not its content length. I reproduced a 15 kbps source and confirmed the tiny segment still decodes to a full-length, valid AV1/480 chunk.

## Testing
- `max_chunk_sec` filter: a node advertising 40s is handed nothing when chunks are 50s; one advertising 120s gets the 50s chunk.
- `py_compile` + `node --check` clean.

## Deploy note
After merging, set `CHUNK_DURATION_SEC = 120` (or lower) in your `config.py` so browser nodes get chunks; native workers are unaffected either way. If 120s chunks still crash the browser on very complex 1080p content, lower **MAX CHUNK SEC** on the page (and `CHUNK_DURATION_SEC` to match). The longer-term way to raise the ceiling is a wasm rebuild with more memory headroom (the `wasm-build/` recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_