### PR TITLE
Hide the /web browser-worker link from the dashboard for now

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -271,11 +271,17 @@
 
                 <div style="text-align: center; margin-top: 30px;">
                     <a href="/dl/worker" target="_blank" class="modal-btn">DOWNLOAD WORKER.PY</a>
-                    <a href="/web" class="modal-btn">ENCODE IN BROWSER</a>
                 </div>
-                <p style="font-size:0.8em; color:#888; text-align:center; margin-top:8px;">
-                    No install needed — encode small files right in your browser (AV1 via WebAssembly).
-                </p>
+                <!-- Browser worker (/web) link hidden for now — the in-browser
+                     encoder isn't reliable yet. The /web route still exists for
+                     testing; re-add this link when it's ready. -->
+                <!--
+                    <a href="/web" class="modal-btn">ENCODE IN BROWSER</a>
+                    <p style="font-size:0.8em; color:#888; text-align:center; margin-top:8px;">
+                        No install needed — encode small files right in your browser (AV1 via WebAssembly).
+                    </p>
+                -->
+
 
                 <div style="margin-top: 30px; border-top: 1px dashed var(--neon-purple); padding-top: 20px;">
                     <span class="os-title" style="color: var(--text-light);">:: SERIES ID REFERENCE</span>


### PR DESCRIPTION
## Summary

Removes the "ENCODE IN BROWSER" link (and its blurb) from the dashboard, since the in-browser encoder isn't reliable enough to point volunteers at yet.

- The `/web` route and all browser-worker code stay in place for testing.
- The link is left **commented out** in `dashboard.html`, so re-adding it later is a one-line uncomment.

No functional/backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_