### PR TITLE
Manager/worker hardening: upload length check, DB backups, source auth, stable series IDs, concurrent reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,13 +388,18 @@ python3 reset_series.py "ShowName"
 
 ### `find_truncated.py`
 Finds completed jobs whose encoded output is much shorter than its source —
-truncated encodes that were accepted before the upload length-check existed
-(and jobs marked completed with no output file on disk):
+truncated encodes that were accepted before the upload length-check existed:
 ```bash
-python3 find_truncated.py              # detect + report only (safe)
-python3 find_truncated.py --requeue    # also reset the bad ones to 'queued'
-python3 find_truncated.py --local-only # skip probing remote sources
+python3 find_truncated.py                # detect + report only (safe)
+python3 find_truncated.py --requeue      # also reset the truncated ones to 'queued'
+python3 find_truncated.py --local-only   # skip probing remote sources
+python3 find_truncated.py --include-missing  # also re-encode jobs with no output file
 ```
+> **Missing outputs are informational by default.** Because finished encodes are
+> routinely moved off-server to archive/storage, a completed job with no file on
+> disk is *expected*, not a defect — those are listed separately and **not**
+> counted as needing re-encode. Only add `--include-missing` if you know those
+> outputs are truly gone and must be regenerated.
 > **RAM mode:** detection is always safe to run, but `--requeue` writes to the
 > disk DB, which a running RAM-mode manager overwrites on its next sync — stop
 > the manager before `--requeue` and start it again after (it reloads the newer

--- a/README.md
+++ b/README.md
@@ -386,6 +386,21 @@ Resets all jobs matching a series name back to `queued` so they re-encode:
 python3 reset_series.py "ShowName"
 ```
 
+### `find_truncated.py`
+Finds completed jobs whose encoded output is much shorter than its source —
+truncated encodes that were accepted before the upload length-check existed
+(and jobs marked completed with no output file on disk):
+```bash
+python3 find_truncated.py              # detect + report only (safe)
+python3 find_truncated.py --requeue    # also reset the bad ones to 'queued'
+python3 find_truncated.py --local-only # skip probing remote sources
+```
+> **RAM mode:** detection is always safe to run, but `--requeue` writes to the
+> disk DB, which a running RAM-mode manager overwrites on its next sync — stop
+> the manager before `--requeue` and start it again after (it reloads the newer
+> disk copy), or re-queue the listed jobs from the admin panel instead. The
+> script warns and asks for confirmation when it detects RAM mode.
+
 ### `update.sh` / `update.ps1`
 Pulls the latest code from git and restarts the service. Run on the manager host.
 

--- a/config.py.example
+++ b/config.py.example
@@ -24,7 +24,19 @@ SECRET_KEY = "ChangeThisToAnotherRandomString"
 # missing token was waved through, so the secret gated nothing. Regular
 # workers already send the token, so they are unaffected. Set False only if
 # you intentionally run a fully open, anonymous-worker manager.
+# This also gates /download_source (the raw source library).
 REQUIRE_WORKER_TOKEN = True
+
+# ==============================================================================
+# DATABASE BACKUPS
+# ==============================================================================
+# The database is the single source of truth for the whole queue and the
+# FractumCoin earnings ledger, so it is backed up on a schedule (consistent
+# SQLite backup, safe while live). Keeps the newest DB_BACKUP_RETENTION copies.
+DB_BACKUP_ENABLED = True
+DB_BACKUP_DIR = "db_backups"
+DB_BACKUP_INTERVAL_HOURS = 12
+DB_BACKUP_RETENTION = 10
 
 # ==============================================================================
 # FILE & DIRECTORY SETTINGS

--- a/find_truncated.py
+++ b/find_truncated.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Find (and optionally re-queue) completed jobs whose encoded output is shorter
+than its source — i.e. truncated encodes that were accepted as "completed"
+before the upload length-check existed.
+
+Run from the same directory as config.py (like the other utility scripts):
+
+    python3 find_truncated.py                 # detect + report only (safe)
+    python3 find_truncated.py --requeue       # also reset the bad ones to 'queued'
+    python3 find_truncated.py --local-only    # skip probing remote sources (faster)
+
+Detection: compares the completed .mp4's duration against the source duration
+(taken from the job's stored source_duration_sec when present, otherwise probed
+with ffprobe). A job is flagged when the output is shorter than the source by
+more than the tolerance (default 5% + 10s), or when its completed file is
+missing entirely. Minor rounding differences are ignored.
+
+Nothing is changed unless you pass --requeue.
+"""
+import argparse
+import os
+import sys
+import subprocess
+from urllib.parse import quote, urljoin
+
+sys.path.append(os.getcwd())
+try:
+    import config
+except ImportError:
+    print("[!] config.py not found. Run this from the same folder as the manager.")
+    sys.exit(1)
+
+DB_FILE             = getattr(config, 'DB_FILE', 'encoding_jobs.db')
+SOURCE_DIRECTORY    = getattr(config, 'SOURCE_DIRECTORY', './source_media')
+COMPLETED_DIRECTORY = getattr(config, 'COMPLETED_DIRECTORY', './completed_media')
+REMOTE_SOURCE_URL   = getattr(config, 'REMOTE_SOURCE_URL', None)
+WORKER_SECRET       = getattr(config, 'WORKER_SECRET', '')
+DB_MODE             = getattr(config, 'DB_MODE', 'disk')
+
+import sqlite3
+
+
+def probe_duration(target, is_remote=False):
+    """Return duration in seconds via ffprobe, or 0.0 on any failure."""
+    cmd = ['ffprobe', '-v', 'error']
+    if is_remote and WORKER_SECRET:
+        cmd += ['-headers', f'X-Worker-Token: {WORKER_SECRET}\r\n']
+    cmd += ['-show_entries', 'format=duration', '-of', 'default=nw=1:nk=1', target]
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        return float((res.stdout or '0').strip() or 0)
+    except Exception:
+        return 0.0
+
+
+def completed_path_for(job_id):
+    return os.path.abspath(os.path.join(COMPLETED_DIRECTORY,
+                                        os.path.splitext(job_id)[0] + ".mp4"))
+
+
+def source_target(job_id, source_type, source_url):
+    if source_type == 'remote':
+        base = source_url or REMOTE_SOURCE_URL
+        return (urljoin(base, quote(job_id)), True) if base else (None, True)
+    return (os.path.join(SOURCE_DIRECTORY, job_id.replace('/', os.sep)), False)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--requeue', action='store_true',
+                    help="Reset flagged jobs to 'queued' so they re-encode.")
+    ap.add_argument('--local-only', action='store_true',
+                    help="Skip jobs whose source is remote (don't probe over HTTP).")
+    ap.add_argument('--tolerance-pct', type=float, default=5.0,
+                    help="Allowed shortfall as %% of source duration (default 5).")
+    ap.add_argument('--min-tolerance', type=float, default=10.0,
+                    help="Minimum allowed shortfall in seconds (default 10).")
+    args = ap.parse_args()
+
+    if not os.path.exists(DB_FILE):
+        print(f"[!] Database '{DB_FILE}' not found.")
+        sys.exit(1)
+
+    conn = sqlite3.connect(DB_FILE)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT id, source_type, source_url, source_duration_sec "
+        "FROM jobs WHERE status='completed' AND id NOT LIKE 'HISTORY_%' ORDER BY id"
+    ).fetchall()
+
+    print(f"[*] Checking {len(rows)} completed job(s)...\n")
+
+    truncated, missing_output, missing_source, undetermined, skipped_remote = [], [], [], [], 0
+
+    for r in rows:
+        job_id = r['id']
+        out_path = completed_path_for(job_id)
+        if not os.path.isfile(out_path):
+            missing_output.append(job_id)
+            continue
+
+        if r['source_type'] == 'remote' and args.local_only:
+            skipped_remote += 1
+            continue
+
+        # Source duration: stored value if present, else probe the source.
+        src_dur = 0.0
+        try:
+            src_dur = float(r['source_duration_sec'] or 0)
+        except (TypeError, ValueError):
+            src_dur = 0.0
+        if src_dur <= 0:
+            tgt, is_remote = source_target(job_id, r['source_type'], r['source_url'])
+            if not tgt or (not is_remote and not os.path.isfile(tgt)):
+                missing_source.append(job_id)
+                continue
+            src_dur = probe_duration(tgt, is_remote)
+        if src_dur <= 0:
+            undetermined.append(job_id)
+            continue
+
+        out_dur = probe_duration(out_path)
+        tolerance = max(args.min_tolerance, src_dur * args.tolerance_pct / 100.0)
+        if out_dur < src_dur - tolerance:
+            truncated.append((job_id, out_dur, src_dur))
+
+    # ---- Report ----
+    if truncated:
+        print(f"[!] {len(truncated)} TRUNCATED encode(s) (output much shorter than source):")
+        for jid, o, s in truncated:
+            print(f"      {o/60:6.1f}m / {s/60:6.1f}m   {jid}")
+    if missing_output:
+        print(f"\n[!] {len(missing_output)} completed job(s) with NO output file on disk:")
+        for jid in missing_output:
+            print(f"      {jid}")
+    if missing_source:
+        print(f"\n[-] {len(missing_source)} job(s) whose source is gone (can't verify/re-encode): {len(missing_source)}")
+    if undetermined:
+        print(f"\n[-] {len(undetermined)} job(s) whose source duration couldn't be determined (skipped).")
+    if skipped_remote:
+        print(f"\n[-] {skipped_remote} remote job(s) skipped (--local-only).")
+
+    to_fix = [t[0] for t in truncated] + missing_output
+    print(f"\n[*] {len(to_fix)} job(s) need re-encoding.")
+
+    if not to_fix:
+        conn.close()
+        return
+
+    if not args.requeue:
+        print("[*] Dry run — re-run with --requeue to reset these to 'queued'.")
+        conn.close()
+        return
+
+    # RAM mode: the live DB is in /dev/shm and the manager overwrites the disk
+    # file every ~60s, so an external write here would be lost. The manager
+    # must be stopped first; on restart it loads the (now newer) disk copy.
+    if DB_MODE == 'ram':
+        print("\n[!] DB_MODE='ram' detected.")
+        print("    A write here will be CLOBBERED by the running manager's RAM->disk sync.")
+        print("    STOP the manager before using --requeue, then start it again after.")
+        print("    (Alternatively, leave the manager running and re-queue each job above")
+        print("     from the admin panel's RETRY button — that goes through the live DB.)")
+        resp = input("    Proceed with the disk write anyway? [y/N]: ").strip().lower()
+        if resp != 'y':
+            print("[*] Aborted. No changes made.")
+            conn.close()
+            return
+
+    from datetime import datetime
+    c = conn.cursor()
+    for jid in to_fix:
+        # Clear any chunk state so it re-encodes cleanly (chunked or whole-file).
+        try:
+            c.execute("DELETE FROM chunks WHERE job_id=?", (jid,))
+        except sqlite3.OperationalError:
+            pass  # pre-chunking DB
+        c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, "
+                  "fail_count=0, chunked=0, chunkable=NULL, started_at=NULL, "
+                  "last_updated=? WHERE id=?", (datetime.now(), jid))
+    conn.commit()
+    conn.close()
+    print(f"[+] Re-queued {len(to_fix)} job(s). They will re-encode on the next worker poll.")
+    print("[*] If the manager runs with DB_MODE='ram', restart it so it reloads the DB,")
+    print("    or trigger a rescan from the admin panel.")
+
+
+if __name__ == "__main__":
+    main()

--- a/find_truncated.py
+++ b/find_truncated.py
@@ -9,12 +9,18 @@ Run from the same directory as config.py (like the other utility scripts):
     python3 find_truncated.py                 # detect + report only (safe)
     python3 find_truncated.py --requeue       # also reset the bad ones to 'queued'
     python3 find_truncated.py --local-only    # skip probing remote sources (faster)
+    python3 find_truncated.py --include-missing  # also re-encode jobs with no file
 
 Detection: compares the completed .mp4's duration against the source duration
 (taken from the job's stored source_duration_sec when present, otherwise probed
-with ffprobe). A job is flagged when the output is shorter than the source by
-more than the tolerance (default 5% + 10s), or when its completed file is
-missing entirely. Minor rounding differences are ignored.
+with ffprobe). A job is flagged as TRUNCATED when the output is shorter than the
+source by more than the tolerance (default 5% + 10s). Minor rounding differences
+are ignored.
+
+Missing output files are reported separately and, by DEFAULT, are treated as
+informational only — outputs are routinely moved off-server to archive/storage,
+so a missing file is expected, not a defect. Pass --include-missing to also
+re-encode those (only do this if you know the outputs are truly gone).
 
 Nothing is changed unless you pass --requeue.
 """
@@ -69,9 +75,14 @@ def source_target(job_id, source_type, source_url):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--requeue', action='store_true',
-                    help="Reset flagged jobs to 'queued' so they re-encode.")
+                    help="Reset TRUNCATED jobs to 'queued' so they re-encode.")
     ap.add_argument('--local-only', action='store_true',
                     help="Skip jobs whose source is remote (don't probe over HTTP).")
+    ap.add_argument('--include-missing', action='store_true',
+                    help="Also treat completed jobs with NO output file on disk as "
+                         "needing re-encode. OFF by default, because outputs are "
+                         "normally moved off-server for storage — a missing file is "
+                         "expected, not a defect.")
     ap.add_argument('--tolerance-pct', type=float, default=5.0,
                     help="Allowed shortfall as %% of source duration (default 5).")
     ap.add_argument('--min-tolerance', type=float, default=10.0,
@@ -131,7 +142,11 @@ def main():
         for jid, o, s in truncated:
             print(f"      {o/60:6.1f}m / {s/60:6.1f}m   {jid}")
     if missing_output:
-        print(f"\n[!] {len(missing_output)} completed job(s) with NO output file on disk:")
+        tag = "[!]" if args.include_missing else "[-]"
+        note = ("" if args.include_missing
+                else "  (not on server — likely moved to archive/storage; "
+                     "NOT counted as needing re-encode)")
+        print(f"\n{tag} {len(missing_output)} completed job(s) with NO output file on disk:{note}")
         for jid in missing_output:
             print(f"      {jid}")
     if missing_source:
@@ -141,8 +156,13 @@ def main():
     if skipped_remote:
         print(f"\n[-] {skipped_remote} remote job(s) skipped (--local-only).")
 
-    to_fix = [t[0] for t in truncated] + missing_output
+    to_fix = [t[0] for t in truncated]
+    if args.include_missing:
+        to_fix += missing_output
     print(f"\n[*] {len(to_fix)} job(s) need re-encoding.")
+    if missing_output and not args.include_missing:
+        print(f"    ({len(missing_output)} missing-output job(s) NOT included — "
+              f"pass --include-missing if those really need re-encoding.)")
 
     if not to_fix:
         conn.close()

--- a/manager.py
+++ b/manager.py
@@ -1,6 +1,7 @@
 import os
 import time
 import threading
+import contextlib
 import sqlite3
 import subprocess
 import json
@@ -92,6 +93,25 @@ try:
     except ImportError:
         REQUIRE_WORKER_TOKEN = True
 
+    # Periodic timestamped backups of the job/earnings database, so a
+    # corruption or bad disk write doesn't wipe the whole queue.
+    try:
+        from config import DB_BACKUP_ENABLED
+    except ImportError:
+        DB_BACKUP_ENABLED = True
+    try:
+        from config import DB_BACKUP_DIR
+    except ImportError:
+        DB_BACKUP_DIR = "db_backups"
+    try:
+        from config import DB_BACKUP_INTERVAL_HOURS
+    except ImportError:
+        DB_BACKUP_INTERVAL_HOURS = 12
+    try:
+        from config import DB_BACKUP_RETENTION
+    except ImportError:
+        DB_BACKUP_RETENTION = 10
+
 except ImportError:
     print("[!] Critical Error: config.py not found.")
     exit(1)
@@ -118,6 +138,14 @@ limiter = Limiter(
 )
 
 db_lock = threading.RLock()
+
+def read_lock():
+    """Lock context for READ-ONLY DB access. With WAL enabled, SQLite allows
+    concurrent readers alongside a writer, so pure reads don't need the global
+    write lock — this keeps dashboard/worker polling from serializing behind
+    every writer. Falls back to the real lock when WAL is off (network-share
+    setups) where concurrent access would otherwise hit 'database is locked'."""
+    return contextlib.nullcontext() if USE_WAL_MODE else db_lock
 
 # --- Chunked encoding state ---
 CHUNK_STORE_DIR = os.path.abspath("chunk_store")   # uploaded chunk files live here until assembly
@@ -241,6 +269,45 @@ class DatabaseHandler:
 
 # Initialize the Handler
 db_handler = DatabaseHandler(DB_FILE, DB_MODE)
+
+def backup_database():
+    """Write a consistent, timestamped copy of the DB to DB_BACKUP_DIR using the
+    SQLite backup API (safe while the DB is live), then prune to the newest
+    DB_BACKUP_RETENTION copies. The DB is the single source of truth for the
+    whole queue + earnings ledger, so this guards against corruption/disk loss."""
+    if not DB_BACKUP_ENABLED:
+        return
+    try:
+        os.makedirs(DB_BACKUP_DIR, exist_ok=True)
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        base = os.path.basename(db_handler.disk_path)
+        dest_path = os.path.join(DB_BACKUP_DIR, f"{base}.{stamp}.bak")
+        src = sqlite3.connect(db_handler.active_db_path)
+        dst = sqlite3.connect(dest_path)
+        try:
+            with dst:
+                src.backup(dst)
+        finally:
+            dst.close(); src.close()
+        # Prune: keep the newest RETENTION backups for this base name.
+        backups = sorted(
+            [f for f in os.listdir(DB_BACKUP_DIR)
+             if f.startswith(base + ".") and f.endswith(".bak")])
+        excess = len(backups) - max(1, int(DB_BACKUP_RETENTION))
+        for old in backups[:max(0, excess)]:
+            try: os.remove(os.path.join(DB_BACKUP_DIR, old))
+            except OSError: pass
+        print(f"[*] DB backup written: {dest_path}")
+    except Exception as e:
+        print(f"[!] DB backup failed: {e}")
+
+def _backup_loop():
+    interval = max(1, int(DB_BACKUP_INTERVAL_HOURS)) * 3600
+    # Take one shortly after startup, then on the configured interval.
+    time.sleep(120)
+    while True:
+        backup_database()
+        time.sleep(interval)
 
 # ==============================================================================
 # LOGGING
@@ -414,6 +481,34 @@ def _chunk_dir(job_id):
     safe = re.sub(r'[^a-zA-Z0-9_.-]', '_', job_id)[:60]
     tag = hashlib.md5(job_id.encode('utf-8', 'replace')).hexdigest()[:10]
     return os.path.join(CHUNK_STORE_DIR, f"{safe}_{tag}")
+
+def _get_or_probe_source_duration(job_id, source_type, source_url, cached_dur):
+    """Return the source video's duration in seconds, using the stored value if
+    present, otherwise probing the source once and caching it on the job row.
+    Returns 0.0 if it can't be determined (callers then skip the length check)."""
+    try:
+        if cached_dur and float(cached_dur) > 0:
+            return float(cached_dur)
+    except (TypeError, ValueError):
+        pass
+    if source_type == 'remote':
+        src = build_download_url(job_id, 'remote', source_url)
+    else:
+        src = os.path.join(SOURCE_DIRECTORY, job_id.replace('/', os.sep))
+        if not os.path.isfile(src):
+            return 0.0
+    probe = _probe_media(src, timeout=60) if src else None
+    dur = probe['duration'] if probe else 0.0
+    if dur > 0:
+        with db_lock:
+            conn = db_handler.get_connection()
+            try:
+                conn.execute("UPDATE jobs SET source_duration_sec=? WHERE id=? AND source_duration_sec IS NULL",
+                             (dur, job_id))
+                conn.commit()
+            finally:
+                conn.close()
+    return dur
 
 def _parse_rate(rate_str):
     """Parse an ffprobe frame-rate fraction like '24000/1001' into a float."""
@@ -1187,6 +1282,26 @@ def _scan_and_queue_inner():
 _SERIES_CACHE = None
 _SERIES_CACHE_TIME = 0.0
 _SERIES_CACHE_LOCK = threading.Lock()
+_SERIES_IDS_FILE = 'series_ids.json'
+
+def _load_series_ids():
+    """folder -> stable integer id, persisted across runs so that adding or
+    removing a source folder never renumbers the others."""
+    try:
+        with open(_SERIES_IDS_FILE, 'r') as f:
+            data = json.load(f)
+        return {k: int(v) for k, v in data.items() if str(v).isdigit()}
+    except Exception:
+        return {}
+
+def _save_series_ids(id_map):
+    tmp = _SERIES_IDS_FILE + '.tmp'
+    try:
+        with open(tmp, 'w') as f:
+            json.dump(id_map, f, indent=2)
+        os.replace(tmp, _SERIES_IDS_FILE)
+    except Exception as e:
+        print(f"[!] Could not persist {_SERIES_IDS_FILE}: {e}")
 
 def get_series_list(force_refresh=False):
     global _SERIES_CACHE, _SERIES_CACHE_TIME
@@ -1213,7 +1328,25 @@ def get_series_list(force_refresh=False):
                         print(f"[!] series_names.json has {len(stale_keys)} stale key(s): {', '.join(stale_keys[:5])}")
                 except: pass
 
-            result = ([{"id": i+1, "folder": f, "name": mapping.get(f, f)} for i, f in enumerate(folders)], stale_keys)
+            # Stable IDs: reuse each folder's persisted id; assign the next free
+            # id to any new folder. IDs are never reused or renumbered, so a
+            # worker pinned with --series-id keeps pointing at the same show even
+            # when other folders are added or removed.
+            id_map = _load_series_ids()
+            changed = False
+            next_id = (max(id_map.values()) + 1) if id_map else 1
+            for f in folders:
+                if f not in id_map:
+                    id_map[f] = next_id
+                    next_id += 1
+                    changed = True
+            if changed:
+                _save_series_ids(id_map)
+
+            series = sorted(
+                [{"id": id_map[f], "folder": f, "name": mapping.get(f, f)} for f in folders],
+                key=lambda s: s["id"])
+            result = (series, stale_keys)
             _SERIES_CACHE = result; _SERIES_CACHE_TIME = now
             return result
         except:
@@ -1440,7 +1573,12 @@ python3 worker.py --username "{u}" --workername "{w}" --jobs {j} --manager "{SER
     return Response(script, mimetype='text/x-shellscript')
 
 @app.route('/download_source/<path:filename>')
+@requires_worker_auth
 def download_source(filename):
+    # Worker-auth gated: previously anyone could download the entire raw source
+    # library. Workers stream it via ffmpeg with the X-Worker-Token header; the
+    # browser uses the /download_media proxy. (No-op when REQUIRE_WORKER_TOKEN
+    # is off, preserving a deliberately open deployment.)
     return send_from_directory(SOURCE_DIRECTORY, filename, as_attachment=True)
 
 @app.route('/download_media')
@@ -1926,7 +2064,7 @@ def upload_result():
             conn = db_handler.get_connection()
             try:
                 c = conn.cursor()
-                c.execute("SELECT status, COALESCE(chunked, 0) FROM jobs WHERE id=?", (job_id,))
+                c.execute("SELECT status, COALESCE(chunked, 0), source_type, source_url, source_duration_sec FROM jobs WHERE id=?", (job_id,))
                 jrow = c.fetchone()
             finally:
                 conn.close()
@@ -1934,6 +2072,7 @@ def upload_result():
             return jsonify({"status": "error", "message": "unknown job"}), 404
         if jrow[1] == 1 or jrow[0] == 'completed':
             return jsonify({"status": "stale", "message": "Job no longer accepts a whole-file upload"}), 409
+        _src_type, _src_url, _src_dur = jrow[2], jrow[3], jrow[4]
 
         new_filename = os.path.splitext(job_id)[0] + ".mp4"
         quarantine_dir = os.path.join("temp_uploads", "quarantine")
@@ -1942,6 +2081,23 @@ def upload_result():
         request.files['file'].save(temp_path)
 
         is_valid, reason, verified_dur = verify_upload(temp_path)
+
+        # Length check: a valid-but-TRUNCATED encode (ffmpeg died near the end
+        # yet exited 0, a resume glitch, etc.) passes the codec/height check but
+        # is missing footage. Compare the delivered duration against the source
+        # and reject shortfalls. (The chunk path already does this per chunk;
+        # this closes the same gap for whole-file uploads.)
+        if is_valid and verified_dur > 0:
+            src_dur = _get_or_probe_source_duration(job_id, _src_type, _src_url, _src_dur)
+            if src_dur and src_dur > 0:
+                # Generous tolerance (5% + 10s floor) so encoder rounding / a
+                # dropped final frame never false-rejects a good encode; it only
+                # catches gross truncation (e.g. half the video missing).
+                tolerance = max(10.0, src_dur * 0.05)
+                if verified_dur < src_dur - tolerance:
+                    is_valid = False
+                    reason = f"Truncated encode ({verified_dur:.0f}s vs source {src_dur:.0f}s)"
+
         if not is_valid:
             log_event("WARN", f"Security: Upload rejected ({reason})", job_id)
             os.remove(temp_path)
@@ -2105,7 +2261,7 @@ def api_error_reports():
     except (ValueError, TypeError):
         limit = 200
 
-    with db_lock:
+    with read_lock():
         conn = db_handler.get_connection()
         conn.row_factory = sqlite3.Row
         try:
@@ -2142,7 +2298,7 @@ def job_status():
     job_id = (request.args.get('job_id', '') or '').strip()
     if not job_id:
         return jsonify({"status": "error", "message": "job_id required"}), 400
-    with db_lock:
+    with read_lock():
         conn = db_handler.get_connection()
         conn.row_factory = sqlite3.Row
         try:
@@ -2283,7 +2439,7 @@ def report_status():
 def api_stats():
     filter_val = request.args.get('filter')
 
-    with db_lock:
+    with read_lock():
         conn = db_handler.get_connection(); conn.row_factory = sqlite3.Row
         try:
             c = conn.cursor()
@@ -2356,7 +2512,7 @@ def api_all_jobs():
     except (ValueError, TypeError):
         limit = 2000
     status_filter = request.args.get('status')
-    with db_lock:
+    with read_lock():
         conn = db_handler.get_connection(); conn.row_factory = sqlite3.Row
         try:
             c = conn.cursor()
@@ -2380,7 +2536,7 @@ def api_earnings():
         limit = min(int(request.args.get('limit', 100)), 1000)
     except (ValueError, TypeError):
         limit = 100
-    with db_lock:
+    with read_lock():
         conn = db_handler.get_connection(); conn.row_factory = sqlite3.Row
         try:
             c = conn.cursor()
@@ -2409,7 +2565,7 @@ def get_logs():
         limit = min(int(request.args.get('limit', 100)), 1000)
     except (ValueError, TypeError):
         limit = 100
-    with db_lock:
+    with read_lock():
         conn = db_handler.get_connection(); conn.row_factory = sqlite3.Row
         try:
             c = conn.cursor()
@@ -2640,8 +2796,10 @@ init_db()
 # Sweep stale quarantine files from any previous crash
 sweep_quarantine()
 # FIXED: Run startup scan in thread to allow Gunicorn to bind immediately
-threading.Thread(target=scan_and_queue, daemon=True).start() 
+threading.Thread(target=scan_and_queue, daemon=True).start()
 threading.Thread(target=maintenance_loop, daemon=True).start()
+if DB_BACKUP_ENABLED:
+    threading.Thread(target=_backup_loop, daemon=True).start()
 print(f"[*] Manager initialized and ready. (Service URL: {SERVER_URL_DISPLAY})")
 
 if __name__ == '__main__':

--- a/worker_template.py
+++ b/worker_template.py
@@ -191,8 +191,13 @@ class QuotaTracker:
     def _save(self):
         today = datetime.now().strftime("%Y-%m-%d")
         try:
-            with open(self.filename, 'w') as f:
+            # Atomic write (temp + rename) so a concurrent reader — e.g. another
+            # worker process sharing this --workername, or check_cap() mid-write —
+            # never sees a half-written file and mis-parses it as "under quota".
+            tmp = f"{self.filename}.{os.getpid()}.tmp"
+            with open(tmp, 'w') as f:
                 json.dump({"date": today, "bytes": self.current_usage}, f)
+            os.replace(tmp, self.filename)
         except: pass
 
     def check_cap(self):
@@ -792,6 +797,19 @@ def signal_handler(sig, frame):
                 sys.stdout.write('\n\n[!] PAUSE REQUESTED (Stopping gracefully...)\n')
                 sys.stdout.flush()
             except: pass
+        else:
+            # Second Ctrl+C while already pausing = force abort, as the pause
+            # menu advertises. A custom SIGINT handler means readline never
+            # raises KeyboardInterrupt, so abort here directly. os._exit is
+            # abrupt by design (that's what "force" means); ffmpeg children are
+            # killed first.
+            try: kill_processes()
+            except: pass
+            try:
+                sys.stdout.write('\n[!] Force abort.\n')
+                sys.stdout.flush()
+            except: pass
+            os._exit(1)
 
 def toggle_processes(suspend=True):
     if platform.system() == 'Windows':
@@ -952,6 +970,24 @@ def get_seconds(t):
         h = int(parts[0]); m = int(parts[1]); s = float(parts[2])
         return h*3600 + m*60 + s
     except: return 0
+
+# ==============================================================================
+# ENCODE HEARTBEAT
+# ==============================================================================
+
+def _start_heartbeat(fn, interval=30):
+    """Run fn() every `interval` seconds on a daemon thread until the returned
+    Event is set. Used to keep sending status to the manager even while the
+    encode loop is blocked in readline() (e.g. ffmpeg SIGSTOP'd during a pause),
+    so a long pause doesn't get the job/chunk reassigned. Extra posts are
+    harmless; the loop's own 10s posts continue when it's running."""
+    stop = threading.Event()
+    def _run():
+        while not stop.wait(interval):
+            try: fn()
+            except Exception: pass
+    threading.Thread(target=_run, daemon=True).start()
+    return stop
 
 # ==============================================================================
 # RESUME / PARTIAL ENCODE HELPERS
@@ -2330,6 +2366,13 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
 
                     with PROC_LOCK: ACTIVE_PROCS[worker_id] = proc
 
+                    # Independent heartbeat: keeps the manager updated even while
+                    # this loop is blocked in readline() with a SIGSTOP'd ffmpeg
+                    # (a pause), so a long pause doesn't get the job reassigned.
+                    _hb = {"pct": 0}
+                    _hb_stop = _start_heartbeat(
+                        lambda: post_status("paused" if PAUSE_REQUESTED else "processing", _hb["pct"]))
+
                     raw_log_path = os.path.join(temp_dir, "encode.log")
                     with open(raw_log_path, 'w', encoding='utf-8') as raw_log:
                         while True:
@@ -2355,6 +2398,7 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                                     curr_sec = get_seconds(time_str)
                                     pct = min(100, int((curr_sec/total_sec)*100))
                                     last_enc_pct = pct
+                                    _hb["pct"] = pct
 
                                     if single_mode: print_progress(worker_id, curr_sec, total_sec, prefix='Enc')
                                     else: update_status(f"Enc {pct}%")
@@ -2365,6 +2409,7 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                                         last_hb = last_rep
                                 except: pass
 
+                    _hb_stop.set()
                     with PROC_LOCK:
                         if worker_id in ACTIVE_PROCS: del ACTIVE_PROCS[worker_id]
 


### PR DESCRIPTION
## Summary

Implements the review improvements (all except the core-count scheduling idea, which you passed on), **plus a `find_truncated.py` tool to clean up encodes that were already accepted before the length check existed.**

## Manager

**1. Whole-file uploads are length-checked (latent data-integrity bug).** A valid-but-*truncated* encode used to be accepted as `completed` with footage missing. Now the delivered duration is compared to the source (probed once, cached in `source_duration_sec`) and short encodes are rejected. Tolerance 5% + 10s so rounding never false-rejects.

**2. Periodic DB backups** (`DB_BACKUP_*`): consistent SQLite backups on a schedule, keeping the newest N — guards the queue + earnings ledger against corruption/disk loss.

**3. `/download_source` gated** behind worker auth (was world-downloadable). No-op when `REQUIRE_WORKER_TOKEN` is off.

**4. Stable series IDs** (`series_ids.json`) instead of positional index, so adding/removing a folder no longer renumbers `--series-id` pins.

**5. Concurrent reads** — read-only endpoints don't take the global write lock under WAL.

## Worker
- Atomic quota-file writes; working non-TUI "second Ctrl+C = force abort"; encode heartbeat thread so a long pause doesn't get the job reassigned.

## Remediation tool — `find_truncated.py`
Finds existing completed jobs whose output is much shorter than the source (pre-fix truncated encodes) or whose output file is missing, and can re-queue them (`--requeue`). Read-only by default; RAM-mode aware (warns that `--requeue` needs the manager stopped, or use admin retry).

## Testing
- Truncated 40s/120s upload → `400`; full → success.
- `/download_source`: 401 without token, 200 with.
- Series IDs stayed stable across a folder remove+add.
- Backup produce + retention prune keeps N valid copies.
- `find_truncated.py`: flags a truncated job + missing-output jobs, leaves good encodes alone, `--requeue` resets only the flagged.
- `py_compile` + `node --check` clean. (Worker pause/quota/Ctrl+C paths compile-checked, not interactively testable here.)

## Deploy note
New optional `config.py` options (`DB_BACKUP_*`), sane defaults. `series_ids.json` auto-created on next scan. To clean up existing truncated encodes: `python3 find_truncated.py` to see them, then re-queue (stop the manager first if RAM mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm