### PR TITLE
Skip worker probes via manager stream layout + full-program audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ The manager detects a `live_action` content profile and tells the worker to redu
 
 ## Chunked Encoding (many workers, one video)
 
-By default the manager splits long videos into ~5-minute **chunks** so that multiple workers — or multiple cores on one machine via `--jobs N` — encode a *single* video in parallel, instead of each worker grabbing a different video. The swarm finishes one file at a time.
+By default the manager splits long videos into **chunks** of at most `CHUNK_DURATION_SEC` seconds (the shipped config uses 120s) so that multiple workers — or multiple cores on one machine via `--jobs N` — encode a *single* video in parallel, instead of each worker grabbing a different video. The swarm finishes one file at a time.
 
 **How it works:**
 
@@ -320,7 +320,7 @@ By default the manager splits long videos into ~5-minute **chunks** so that mult
 - Videos shorter than ~1.5× the chunk length, VFR sources, and sources whose audio/video streams start at different offsets are encoded whole via the classic path.
 - If a chunk fails 3 times, or assembly fails, the job automatically falls back to whole-file encoding.
 - Chunks with no heartbeat for 30 minutes are handed to another worker; completed chunks are never lost when a worker dies (only the in-flight chunk is redone). If a split job sees no chunk activity at all for 6 hours (e.g. every chunk-capable worker left), it is returned to the normal queue without penalty.
-- Old workers and the browser-based web worker keep using `/get_job` untouched.
+- Old workers keep using `/get_job` untouched. The browser worker takes video chunks too (via pre-cut segments — see below), and falls back to `/get_job` for small whole files.
 - Watermarks (`--watermark`) are skipped on chunks so the final video is consistent.
 
 ### Server-side segmentation (browser workers on big files)
@@ -339,7 +339,7 @@ So a browser volunteer only ever downloads ~one chunk's worth of data (e.g. ~30 
 
 ```python
 CHUNKED_ENCODING = True     # set False to disable splitting entirely
-CHUNK_DURATION_SEC = 300    # target chunk length in seconds
+CHUNK_DURATION_SEC = 120    # maximum chunk length in seconds (no chunk exceeds this)
 ```
 
 > **Note:** the manager temporarily stores uploaded chunks in `chunk_store/` until assembly — keep roughly one encoded video's worth of free disk per active chunked job.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ By default the manager splits long videos into ~5-minute **chunks** so that mult
 
 **Quality / size impact:** effectively none. Encoding is CRF-based (constant quality, not bitrate-targeted), so per-chunk encoding produces the same quality as a single pass. The only overhead is one extra keyframe at each chunk boundary — SVT-AV1 already places keyframes every few seconds, so the size difference is negligible. The final concat is a bit-exact stream copy.
 
+**Probe once, reuse everywhere:** when the manager probes a source (to plan the split), it records the stream layout — the chosen audio track, its channel count, and any subtitle tracks — on the job. Workers are then handed that layout with their chunk/job and **skip their own `ffprobe`**. This matters most on constrained nodes: a Raspberry Pi range-streaming a large MKV over HTTP could otherwise sit on "Probe" for minutes (and, for MKVs whose index sits at the end of the file, occasionally time out and retry). Workers still fall back to probing themselves if the manager hasn't recorded a layout yet (older manager, or a job that never went through a split attempt). Fully backward compatible — the field is additive and ignored by old workers.
+
 **Fallbacks & safety:**
 
 - Videos shorter than ~1.5× the chunk length, VFR sources, and sources whose audio/video streams start at different offsets are encoded whole via the classic path.

--- a/config.py.example
+++ b/config.py.example
@@ -92,9 +92,3 @@ CHUNKED_ENCODING = True
 # any length. If you want browser volunteers to help on big videos, keep this
 # at/below their MAX CHUNK SEC (120 is a safe starting point).
 CHUNK_DURATION_SEC = 120
-
-# ==============================================================================
-# RATE LIMITING
-# ==============================================================================
-# Limits how many jobs a single IP can TAKE per hour.
-RATE_LIMIT_JOBS_PER_HOUR = 15

--- a/find_truncated.py
+++ b/find_truncated.py
@@ -132,6 +132,12 @@ def main():
             continue
 
         out_dur = probe_duration(out_path)
+        if out_dur <= 0:
+            # ffprobe failed on the OUTPUT (missing ffprobe, timeout, ...).
+            # That's "couldn't check", not "truncated" — flagging it would
+            # re-queue perfectly good encodes en masse.
+            undetermined.append(job_id)
+            continue
         tolerance = max(args.min_tolerance, src_dur * args.tolerance_pct / 100.0)
         if out_dur < src_dur - tolerance:
             truncated.append((job_id, out_dur, src_dur))
@@ -150,9 +156,13 @@ def main():
         for jid in missing_output:
             print(f"      {jid}")
     if missing_source:
-        print(f"\n[-] {len(missing_source)} job(s) whose source is gone (can't verify/re-encode): {len(missing_source)}")
+        print(f"\n[-] {len(missing_source)} job(s) whose source is gone (can't verify/re-encode):")
+        for jid in missing_source:
+            print(f"      {jid}")
     if undetermined:
-        print(f"\n[-] {len(undetermined)} job(s) whose source duration couldn't be determined (skipped).")
+        print(f"\n[-] {len(undetermined)} job(s) whose duration couldn't be determined (skipped):")
+        for jid in undetermined:
+            print(f"      {jid}")
     if skipped_remote:
         print(f"\n[-] {skipped_remote} remote job(s) skipped (--local-only).")
 

--- a/manager.py
+++ b/manager.py
@@ -542,6 +542,26 @@ def _probe_media(src, timeout=60):
         has_subs = any(s.get('codec_type') == 'subtitle'
                        and s.get('codec_name', '').lower() in sub_codecs
                        for s in streams)
+
+        # Pick the exact audio track and subtitle tracks a worker would choose,
+        # so the worker can be handed this layout and skip its own (slow, over
+        # HTTP) probe. This MUST mirror the worker's selection logic verbatim.
+        audio_index = None; audio_channels = 2; subtitle_indices = []
+        audio_streams = [s for s in streams if s.get('codec_type') == 'audio']
+        if audio_streams:
+            audio_index = audio_streams[0].get('index')
+            for s in audio_streams:
+                if s.get('tags', {}).get('language', '').lower() in ('eng', 'en', 'english'):
+                    audio_index = s.get('index'); break
+            for s in audio_streams:
+                if s.get('index') == audio_index:
+                    try: audio_channels = int(s.get('channels', 2))
+                    except (TypeError, ValueError): audio_channels = 2
+                    break
+        for s in streams:
+            if (s.get('codec_type') == 'subtitle'
+                    and s.get('codec_name', '').lower() in sub_codecs):
+                subtitle_indices.append(s.get('index'))
         audio_start = None
         first_audio = next((s for s in streams if s.get('codec_type') == 'audio'), None)
         if first_audio is not None:
@@ -564,8 +584,26 @@ def _probe_media(src, timeout=60):
             "duration": dur, "has_audio": has_audio, "has_subs": has_subs,
             "fps": fps, "start_time": start_time, "cfr": is_cfr,
             "format_start": format_start, "audio_start": audio_start,
+            "audio_index": audio_index, "audio_channels": audio_channels,
+            "subtitle_indices": subtitle_indices,
         }
     except Exception:
+        return None
+
+
+def _stream_meta_json(probe):
+    """Build the compact stream-layout blob handed to workers so they can skip
+    their own probe. Returns a JSON string, or None if the probe is unusable."""
+    if not probe:
+        return None
+    try:
+        return json.dumps({
+            "duration": probe.get("duration") or 0,
+            "audio_index": probe.get("audio_index"),
+            "audio_channels": probe.get("audio_channels") or 2,
+            "subtitle_indices": probe.get("subtitle_indices") or [],
+        })
+    except (TypeError, ValueError):
         return None
 
 def _plan_chunks(duration_sec, fps, start_time=0.0):
@@ -746,10 +784,14 @@ def _split_claimed_job(job):
                 # Too short / VFR / unprobeable: hand it back for whole-file
                 # encoding. Guarded so we don't clobber the job if an admin
                 # reset it (and a worker re-claimed it) while we were probing.
+                # Still record the stream layout when we have it, so the
+                # whole-file worker can skip its own probe.
                 c.execute("UPDATE jobs SET status='queued', worker_id=NULL, started_at=NULL, "
-                          "chunkable=0, source_duration_sec=?, last_updated=? "
+                          "chunkable=0, source_duration_sec=?, stream_meta=COALESCE(stream_meta, ?), "
+                          "last_updated=? "
                           "WHERE id=? AND status='processing' AND worker_id='(chunking)'",
-                          (probe['duration'] if probe else None, datetime.now(), job_id))
+                          (probe['duration'] if probe else None, _stream_meta_json(probe),
+                           datetime.now(), job_id))
                 conn.commit()
                 return False
 
@@ -760,9 +802,10 @@ def _split_claimed_job(job):
             # whole-file worker via /get_job after such a reset) may have taken
             # the job while the probe ran. If the claim is gone, walk away.
             c.execute("UPDATE jobs SET chunked=1, chunkable=1, source_duration_sec=?, total_chunks=?, "
+                      "stream_meta=COALESCE(stream_meta, ?), "
                       "progress=0, worker_id='(chunked)', last_updated=? "
                       "WHERE id=? AND status='processing' AND worker_id='(chunking)'",
-                      (duration, total, now, job_id))
+                      (duration, total, _stream_meta_json(probe), now, job_id))
             if c.rowcount != 1:
                 conn.commit()
                 log_event("WARN", "Split abandoned: job was taken by someone else during the probe.", job_id)
@@ -816,7 +859,7 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=Fals
                 params.append(int(max_size_mb) * 1024 * 1024)
             sql = ("SELECT c.rowid AS chunk_rowid, c.job_id, c.kind, c.chunk_index, c.start_sec, c.duration_sec, "
                    "j.filename, j.file_size, j.source_type, j.source_url, j.content_profile, "
-                   "j.source_duration_sec, j.total_chunks "
+                   "j.source_duration_sec, j.total_chunks, j.stream_meta "
                    "FROM chunks c JOIN jobs j ON j.id = c.job_id "
                    f"WHERE {' AND '.join(query_parts)} "
                    "ORDER BY j.started_at ASC, CASE WHEN c.kind='audio' THEN 0 ELSE 1 END, c.chunk_index ASC "
@@ -827,6 +870,13 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=Fals
             if row is None:
                 return None
             chunk = dict(row)
+            # Only the audio chunk probes the source; hand it the pre-computed
+            # stream layout so it can skip that probe. Video chunks don't need
+            # it — drop it to keep the payload small.
+            _sm = chunk.pop('stream_meta', None)
+            if chunk['kind'] == 'audio' and _sm:
+                try: chunk['stream_meta'] = json.loads(_sm)
+                except (TypeError, ValueError): pass
             # The final video chunk encodes to EOF instead of using -t.
             # Computed as a separate single-row query so the assignment scan
             # doesn't pay a correlated subquery per candidate row.
@@ -1406,6 +1456,13 @@ def init_db():
         except sqlite3.OperationalError: pass
         try: cursor.execute("ALTER TABLE jobs ADD COLUMN total_chunks INTEGER DEFAULT 0")
         except sqlite3.OperationalError: pass
+        # [ADDED] stream_meta: JSON blob of the source's stream layout (chosen
+        # audio track, channel count, subtitle track indices, duration) captured
+        # when the manager probes the source. Handed to workers so they can skip
+        # their own probe — the slowest, most fragile step on constrained nodes
+        # (e.g. a Raspberry Pi range-streaming a large MKV over HTTP).
+        try: cursor.execute("ALTER TABLE jobs ADD COLUMN stream_meta TEXT")
+        except sqlite3.OperationalError: pass
 
         # Chunk work-items for split jobs.  kind = 'video' (a time range) or
         # 'audio' (full-length audio + subtitles, encoded once by one worker).
@@ -1707,7 +1764,7 @@ def get_job():
                             params.append(f"{folder_filter}%")
                         
                         # [ADDED] content_profile to SELECT query
-                        sql = f"SELECT id, filename, file_size, source_type, source_url, content_profile, source_hash FROM jobs WHERE {' AND '.join(query_parts)} ORDER BY id ASC LIMIT 1"
+                        sql = f"SELECT id, filename, file_size, source_type, source_url, content_profile, source_hash, stream_meta FROM jobs WHERE {' AND '.join(query_parts)} ORDER BY id ASC LIMIT 1"
                         c.execute(sql, tuple(params)); row = c.fetchone()
                         if row: job = dict(row); break
                 
@@ -1730,6 +1787,12 @@ def get_job():
         # Never reveal the hash to the worker — workers must submit their own
         # computed hash blind so they cannot cheat by echoing the known value.
         job.pop('source_hash', None)
+        # Parse the pre-computed stream layout (if the source was already probed
+        # during a chunk-split attempt) so the worker can skip its own probe.
+        _sm = job.pop('stream_meta', None)
+        if _sm:
+            try: job['stream_meta'] = json.loads(_sm)
+            except (TypeError, ValueError): pass
         if needs_hash:
             _src_path = os.path.join(SOURCE_DIRECTORY, job['id'].replace('/', os.sep))
             _computed = _fast_hash_file(_src_path)

--- a/manager.py
+++ b/manager.py
@@ -1,4 +1,5 @@
 import os
+import math
 import time
 import threading
 import contextlib
@@ -200,10 +201,21 @@ class DatabaseHandler:
             if not os.path.exists(self.disk_path):
                 open(self.disk_path, 'a').close()
 
-            if (os.path.exists(self.ram_path)
-                    and os.path.getmtime(self.ram_path) > os.path.getmtime(self.disk_path) + 1):
+            # In WAL mode the newest commits live in the -wal sidecar, not the
+            # main file — after an unclean shutdown the RAM .db's mtime can look
+            # stale while its -wal holds minutes of newer work. Consider both.
+            ram_wal = self.ram_path + '-wal'
+            ram_mtime = 0.0
+            if os.path.exists(self.ram_path):
+                ram_mtime = os.path.getmtime(self.ram_path)
+                if os.path.exists(ram_wal):
+                    ram_mtime = max(ram_mtime, os.path.getmtime(ram_wal))
+
+            if ram_mtime > os.path.getmtime(self.disk_path) + 1:
                 print("[!] DB Mode: surviving RAM copy is newer than disk — recovering it to disk.")
                 try:
+                    # Opening the RAM DB replays its -wal, so the backup below
+                    # captures those newest commits too.
                     src = sqlite3.connect(self.ram_path)
                     dst = sqlite3.connect(self.disk_path)
                     with dst:
@@ -218,7 +230,14 @@ class DatabaseHandler:
                     pass
                 return
 
-            # Copy to RAM
+            # Copy to RAM. Any stale WAL sidecars from a previous run MUST go
+            # first: SQLite would replay old -wal frames against the replaced
+            # database file — a documented corruption vector.
+            for _side in (ram_wal, self.ram_path + '-shm'):
+                try:
+                    if os.path.exists(_side): os.remove(_side)
+                except OSError as e:
+                    print(f"[!] Could not remove stale sidecar {_side}: {e}")
             shutil.copy2(self.disk_path, self.ram_path)
 
             # Set permissions
@@ -617,7 +636,11 @@ def _plan_chunks(duration_sec, fps, start_time=0.0):
         return None
     if duration_sec < CHUNK_DURATION_SEC * 1.5:
         return None
-    n = max(2, int(round(duration_sec / CHUNK_DURATION_SEC)))
+    # Ceil, not round: no chunk may exceed CHUNK_DURATION_SEC. Browser (wasm)
+    # workers advertise a max chunk length and are only handed chunks at or
+    # under it — with round(), a 290s video split at target 120 produced two
+    # 145s chunks that NO default browser could take, wedging the job.
+    n = max(2, math.ceil(duration_sec / CHUNK_DURATION_SEC))
     n = min(n, 400)
     target = duration_sec / n
     bounds = [0.0]
@@ -633,6 +656,24 @@ def _plan_chunks(duration_sec, fps, start_time=0.0):
             return None  # degenerate plan (absurd fps/duration metadata)
         ranges.append((start, round(end - start, 5)))
     return ranges
+
+def _pending_chunks_exist(folder_filter):
+    """True when any split job still has pending chunks, IGNORING per-worker
+    capability filters (video_only / max_chunk_sec). Used to distinguish a
+    genuinely empty chunk pool from 'chunks exist but this worker can't take
+    them' — the latter must NOT trigger splitting another queued job."""
+    with db_lock:
+        conn = db_handler.get_connection()
+        try:
+            q = ("SELECT 1 FROM chunks c JOIN jobs j ON j.id = c.job_id "
+                 "WHERE c.status='pending' AND j.status='processing' AND COALESCE(j.chunked,0)=1")
+            params = []
+            if folder_filter:
+                q += " AND j.id LIKE ?"
+                params.append(f"{folder_filter}%")
+            return conn.execute(q + " LIMIT 1", params).fetchone() is not None
+        finally:
+            conn.close()
 
 def _resolve_folder_filter(series_id):
     """Map a numeric series_id to its folder prefix, or None."""
@@ -787,8 +828,8 @@ def _split_claimed_job(job):
                 # Still record the stream layout when we have it, so the
                 # whole-file worker can skip its own probe.
                 c.execute("UPDATE jobs SET status='queued', worker_id=NULL, started_at=NULL, "
-                          "chunkable=0, source_duration_sec=?, stream_meta=COALESCE(stream_meta, ?), "
-                          "last_updated=? "
+                          "chunkable=0, source_duration_sec=COALESCE(source_duration_sec, ?), "
+                          "stream_meta=COALESCE(stream_meta, ?), last_updated=? "
                           "WHERE id=? AND status='processing' AND worker_id='(chunking)'",
                           (probe['duration'] if probe else None, _stream_meta_json(probe),
                            datetime.now(), job_id))
@@ -845,10 +886,13 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=Fals
                 query_parts.append("c.kind='video'")
             if max_chunk_sec:
                 try:
-                    query_parts.append("c.duration_sec <= ?")
-                    params.append(float(max_chunk_sec))
+                    _mcs = float(max_chunk_sec)
                 except (TypeError, ValueError):
-                    pass
+                    pass  # malformed value: ignore the cap entirely — appending
+                          # the clause before converting left an unbound '?'
+                else:
+                    query_parts.append("c.duration_sec <= ?")
+                    params.append(_mcs)
             if folder_filter:
                 query_parts.append("j.id LIKE ?")
                 params.append(f"{folder_filter}%")
@@ -894,7 +938,14 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=Fals
             # Browser workers can't range-stream a multi-GB source, so they fetch
             # a small pre-cut segment for this chunk instead (see /download_segment).
             if chunk['kind'] == 'video':
-                chunk['segment_url'] = (f"{SERVER_URL_DISPLAY.rstrip('/')}/download_segment"
+                # Relative URL, NOT SERVER_URL_DISPLAY: the /web page may be
+                # opened via LAN IP/localhost while the display URL is the
+                # public domain — an absolute URL there is cross-origin, which
+                # the page's COEP (require-corp) blocks and whose custom
+                # X-Worker-Token header would force an unanswered CORS
+                # preflight. The whole-file path already uses a relative
+                # /download_media for exactly this reason.
+                chunk['segment_url'] = (f"/download_segment"
                                         f"?job_id={quote(chunk['job_id'], safe='')}&chunk_index={chunk['chunk_index']}")
             return chunk
         finally:
@@ -1840,6 +1891,13 @@ def get_chunk():
         folder_filter = _resolve_folder_filter(series_id)
 
         chunk = _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=video_only, max_chunk_sec=max_chunk_sec)
+        if chunk is None and max_chunk_sec and _pending_chunks_exist(folder_filter):
+            # Chunks ARE pending — this capped worker just can't take any of
+            # them. Splitting another queued job here would convert one more
+            # job to 'processing' per poll (its chunks equally untakeable),
+            # eventually wedging the whole queue behind the 6-hour backstop.
+            # Let the worker fall back to /get_job instead.
+            return jsonify({"status": "empty"})
         if chunk is None:
             if SPLIT_LOCK.acquire(blocking=False):
                 # No pending chunks anywhere — split the next queued job.
@@ -2196,8 +2254,12 @@ def upload_result():
                     (worker_id, datetime.now(), duration, job_id))
                 # FractumCoin credit: minutes come from ffprobe of the delivered
                 # file, not the worker's claim. A re-upload to an already
-                # completed job (stale worker) earns nothing twice.
-                if prev is not None and prev[0] != 'completed':
+                # completed job (stale worker) earns nothing twice, and the
+                # rowcount guard stops a credit when the UPDATE matched nothing
+                # (job was reset+re-split to chunked during the slow verify —
+                # the chunk workers earn per chunk; crediting the straggler too
+                # would be a double payout).
+                if c.rowcount == 1 and prev is not None and prev[0] != 'completed':
                     _record_earning(conn, wallet, worker_id, job_id, 'full', None, verified_dur / 60.0)
                 conn.commit()
             finally:
@@ -2213,7 +2275,12 @@ def upload_result():
 @app.route('/upload_log', methods=['POST'])
 @requires_worker_auth
 def receive_log():
-    MAX_LOG_BYTES = 50 * 1024 * 1024  # 50 MB hard cap
+    MAX_LOG_BYTES = 50 * 1024 * 1024      # 50 MB hard cap (compressed)
+    MAX_LOG_TEXT  = 16 * 1024 * 1024      # decompressed text we'll scan — the
+                                          # cheat markers all appear early; an
+                                          # unbounded read of a gzip bomb (50 MB
+                                          # of zeros → multi-GB string) would
+                                          # OOM the single gunicorn worker
     if request.content_length and request.content_length > MAX_LOG_BYTES:
         return jsonify({"status": "error", "message": "Log file exceeds 50 MB limit"}), 413
 
@@ -2233,7 +2300,16 @@ def receive_log():
         safe_name = re.sub(r'[^a-zA-Z0-9_.-]', '_', job_id)
         log_path = os.path.join(log_dir, f"{safe_name}.log.gz")
         request.files['log_file'].save(log_path)
-        
+
+        # Re-check on disk: content_length is absent on chunked transfers, so
+        # the header check above can be bypassed.
+        try:
+            if os.path.getsize(log_path) > MAX_LOG_BYTES:
+                os.remove(log_path)
+                return jsonify({"status": "error", "message": "Log file exceeds 50 MB limit"}), 413
+        except OSError:
+            pass
+
         warnings = []
         # Audio chunks contain no video encoder — the video cheat checks below
         # would false-positive on them.
@@ -2241,7 +2317,8 @@ def receive_log():
         try:
             if not is_audio_chunk_log:
                 with gzip.open(log_path, 'rt', encoding='utf-8', errors='ignore') as f:
-                    log_content = f.read().lower()
+                    # Bounded read: never inflate more than MAX_LOG_TEXT into RAM.
+                    log_content = f.read(MAX_LOG_TEXT).lower()
 
                     # 1. Check for GPU Encoders (Safely)
                     mapping_block = re.search(r'stream mapping:(.*?)(?:press \[|output #)', log_content, re.DOTALL)

--- a/static/web_node.js
+++ b/static/web_node.js
@@ -162,13 +162,16 @@ async function processChunk(chunk) {
 
         // Same targets as the native chunk path: video-only, SVT-AV1 preset 2,
         // CRF (profile-aware), 480p, timestamps re-zeroed for clean concat.
+        // lp=1 only limits encoder threading (browser memory), it does not
+        // change the bitstream — no tune override, so browser chunks match
+        // native chunks (SVT default tune) when tiled into one video.
         const args = [
             '-threads', '1', '-v', 'verbose',
             '-ss', lead.toFixed(3), '-i', segPath, '-t', dur.toFixed(3),
             '-map', '0:v:0', '-an', '-sn',
             '-c:v', 'libsvtav1', '-preset', '2', '-crf', crf,
             '-pix_fmt', 'yuv420p',
-            '-svtav1-params', 'tune=0:lp=1',
+            '-svtav1-params', 'lp=1',
             '-vf', 'setpts=PTS-STARTPTS,scale=-2:480',
             '-movflags', '+faststart',
             outPath
@@ -256,14 +259,21 @@ async function processJob(job) {
         postMessage({type: 'log', level: 'sys', msg: "Starting FFmpeg..."});
         
         // STRICT ENCODING CONFIGURATION
-        // Matches the manager's verified target: SVT-AV1 preset 2 / CRF 63, 480p,
-        // mono Opus. Notes specific to the browser build:
+        // Matches the manager's verified target: SVT-AV1 preset 2 / CRF 63
+        // (57 for the live_action profile, same as native workers), 480p,
+        // mono Opus 24k. Notes specific to the browser build:
         //  - This wasm has --disable-ffprobe, so we can't inspect streams. We map
         //    the first video + first (optional) audio explicitly and drop
         //    subtitles (-sn): blindly transcoding an unknown subtitle codec to
         //    mov_text is a common hard-failure, and bitmap subs can't convert.
-        //  - A single -svtav1-params: the previous two flags silently overrode
-        //    each other (only the last applied). lp=1 keeps browser memory down.
+        //  - lp=1 keeps browser memory down (native workers pass no
+        //    -svtav1-params; lp only limits threading, not the bitstream).
+        //  - '-c:a opus' + '-strict -2' is FFmpeg's built-in encoder: the
+        //    DEPLOYED wasm was configured without --enable-libopus, so libopus
+        //    isn't available. The wasm-build/ Dockerfile DOES enable it — after
+        //    a rebuild, switch this to '-c:a libopus' (and drop -strict) for
+        //    parity with native workers.
+        const crf = (job.content_profile === 'live_action') ? '57' : '63';
         const args = [
             '-threads', '1',
             '-v', 'verbose',
@@ -273,13 +283,12 @@ async function processJob(job) {
             '-sn',
             '-c:v', 'libsvtav1',
             '-preset', '2',
-            '-crf', '63',
-            '-g', '240',
+            '-crf', crf,
             '-pix_fmt', 'yuv420p',
-            '-svtav1-params', 'tune=0:lp=1',
+            '-svtav1-params', 'lp=1',
             '-vf', 'scale=-2:480',
             '-c:a', 'opus',
-            '-b:a', '12k',
+            '-b:a', '24k',
             '-ac', '1',
             '-strict', '-2',
             outputPath

--- a/templates/web_worker.html
+++ b/templates/web_worker.html
@@ -238,7 +238,7 @@
     let currentChunk = null;   // {job_id, chunk_index} of an in-flight chunk, for release + heartbeat
 
     // Must be >= manager MIN_CLIENT_VERSION or /get_job returns "Update Required".
-    const WEB_WORKER_VERSION = "3.3.0";
+    const WEB_WORKER_VERSION = "3.4.0";
 
     // Worker token: injected by the manager (/web) so the page authenticates
     // out of the box; ?token= in the URL overrides. Empty only if the manager
@@ -261,8 +261,8 @@
     function stopLoop() {
         isRunning = false;
         log("STOP command received. Finishing current job...", 'err');
-        // Release the in-flight job so it doesn't sit 'processing' until the
-        // manager's ~10-min stale sweep before another worker can take it.
+        // Release the in-flight job immediately so it doesn't sit 'processing'
+        // until the manager's dead-job timeout before another worker takes it.
         if (currentJobId) {
             try {
                 fetch('/report_status' + (WORKER_TOKEN ? ('?token=' + encodeURIComponent(WORKER_TOKEN)) : ''), {
@@ -307,6 +307,21 @@
                                        progress: 0, version: WEB_WORKER_VERSION })
             }).catch(() => {});
         }, 15000);
+        return () => clearInterval(id);
+    }
+
+    // Same idea for whole-file jobs: without heartbeats a slow multi-hour
+    // browser encode would hit the manager's dead-job timeout and get
+    // requeued (and encoded twice). Returns a stop() function.
+    function startJobHeartbeat(jobId) {
+        const id = setInterval(() => {
+            fetch('/report_status' + (WORKER_TOKEN ? ('?token=' + encodeURIComponent(WORKER_TOKEN)) : ''), {
+                method: 'POST', headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ job_id: jobId, worker_id: currentWorkerId,
+                                       status: 'processing', progress: 0,
+                                       version: WEB_WORKER_VERSION })
+            }).catch(() => {});
+        }, 30000);
         return () => clearInterval(id);
     }
 
@@ -388,7 +403,10 @@
                 // A. CHUNK FIRST — take a slice of a large video via a pre-cut
                 // segment (video_only: browsers can't do the whole-file audio
                 // chunk). This is how browser nodes help on multi-GB sources.
-                const cres = await fetch(`/get_chunk?video_only=1&max_size_mb=${currentMaxSizeMb}&max_chunk_sec=${currentMaxChunkSec}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
+                // worker_id MUST be sent: assignments recorded with a NULL
+                // worker_id can never be released by our stop/failure reports
+                // (the manager's ownership guards are `AND worker_id=?`).
+                const cres = await fetch(`/get_chunk?video_only=1&worker_id=${encodeURIComponent(currentWorkerId)}&max_size_mb=${currentMaxSizeMb}&max_chunk_sec=${currentMaxChunkSec}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
                 if (cres.status === 200) {
                     const cdata = await cres.json();
                     if (cdata.status === 'ok' && cdata.chunk) {
@@ -409,7 +427,7 @@
 
                 // B. GET JOB (whole small files) — must send the version param or
                 // the manager's MIN_CLIENT_VERSION gate returns "Update Required".
-                const res = await fetch(`/get_job?max_size_mb=${currentMaxSizeMb}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
+                const res = await fetch(`/get_job?worker_id=${encodeURIComponent(currentWorkerId)}&max_size_mb=${currentMaxSizeMb}&version=${encodeURIComponent(WEB_WORKER_VERSION)}${_authQS}`);
                 const data = await res.json();
 
                 if (res.status === 401) {
@@ -445,8 +463,34 @@
 
             } catch (e) {
                 log("LOOP ERROR: " + e.message, 'err');
+                // Report the failure so the manager releases the work NOW and
+                // counts the strike (3 chunk failures → whole-file fallback) —
+                // silence would leave it assigned until the 30-min/4-h sweeps.
+                if (currentChunk) {
+                    try {
+                        fetch('/report_chunk' + (WORKER_TOKEN ? ('?token=' + encodeURIComponent(WORKER_TOKEN)) : ''), {
+                            method: 'POST', headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({ job_id: currentChunk.job_id, chunk_index: currentChunk.chunk_index,
+                                                   kind: 'video', worker_id: currentWorkerId,
+                                                   status: 'failed', error: String(e.message || e).slice(0, 500),
+                                                   version: WEB_WORKER_VERSION })
+                        });
+                    } catch (re) { /* best effort */ }
+                    currentChunk = null;
+                }
+                if (currentJobId) {
+                    try {
+                        fetch('/report_status' + (WORKER_TOKEN ? ('?token=' + encodeURIComponent(WORKER_TOKEN)) : ''), {
+                            method: 'POST', headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({ job_id: currentJobId, worker_id: currentWorkerId,
+                                                   status: 'failed', error: String(e.message || e).slice(0, 500),
+                                                   version: WEB_WORKER_VERSION })
+                        });
+                    } catch (re) { /* best effort */ }
+                    currentJobId = null;
+                }
                 // If the error implies worker crash, restart it
-                if (worker === null) { 
+                if (worker === null) {
                     log("Worker seems dead. Restarting...", 'err');
                     try { await initWorker(); } catch(err) { isRunning = false; }
                 }
@@ -465,24 +509,24 @@
                 return;
             }
 
-            // Define temporary handler for this job
-            const originalOnMsg = worker.onmessage;
-            
+            const stopHb = startJobHeartbeat(job.id);
+
             worker.onmessage = (e) => {
                 const msg = e.data;
                 if (msg.type === 'log') {
                     log(msg.msg, msg.level);
                 } else if (msg.type === 'done') {
-                    // Restore original handler (for logs/ready) or just keep it?
-                    // Re-init handles logging generally.
+                    stopHb();
                     resolve();
                 } else if (msg.type === 'error') {
+                    stopHb();
                     reject(new Error(msg.msg));
                 }
             };
-            
+
             // If worker crashes/terminates during job
             worker.onerror = (e) => {
+                stopHb();
                 reject(new Error("Worker Crashed: " + e.message));
                 worker = null; // Mark as dead
             };

--- a/worker_template.py
+++ b/worker_template.py
@@ -113,7 +113,7 @@ except ImportError as _e:
 DEFAULT_MANAGER_URL = "https://encode.fractumseraph.net/"
 DEFAULT_USERNAME = "Anonymous"
 DEFAULT_WORKERNAME = f"Node-{int(time.time())}"
-WORKER_VERSION = "3.3.0"
+WORKER_VERSION = "3.4.0"
 WORKER_SECRET = os.environ.get("WORKER_SECRET", "DefaultInsecureSecret")
 
 SHUTDOWN_EVENT = threading.Event()
@@ -1493,41 +1493,62 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
             prog_total = dur_sec
         else:
             # Audio + subtitles for the whole file, encoded once.
-            update_status("Probing")
-            probe_data = None
-            for _pa in range(3):
-                try:
-                    cmd_probe = ([FFPROBE_CMD] if _is_local else [FFPROBE_CMD, '-headers', ffmpeg_http_headers]) + \
-                                ['-v', 'quiet', '-print_format', 'json', '-show_streams', '-show_format', dl_url]
-                    res = subprocess.run(cmd_probe, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                         encoding='utf-8', errors='replace', timeout=60)
-                    probe_data = json.loads(res.stdout)
-                    break
-                except Exception as _pe:
-                    if _pa < 2:
-                        time.sleep(5 * (_pa + 1))
-                    else:
-                        log(worker_id, f"Chunk probe failed: {_pe}", "ERROR")
-            if probe_data is None:
-                report_chunk("failed", error_msg="FFprobe failed after 3 attempts")
-                return
-
             audio_index = None; subtitle_indices = []; audio_channels = 2
-            audio_streams = [s for s in probe_data.get('streams', []) if s['codec_type'] == 'audio']
-            if audio_streams:
-                audio_index = audio_streams[0]['index']
-                for s in audio_streams:
-                    if s.get('tags', {}).get('language', '').lower() in ['eng', 'en', 'english']:
-                        audio_index = s['index']; break
-                for s in audio_streams:
-                    if s['index'] == audio_index:
-                        try: audio_channels = int(s.get('channels', 2))
-                        except: pass
+            # The manager may have handed us the source's stream layout (from its
+            # own probe), letting us skip probing over HTTP — the slowest and most
+            # failure-prone step on constrained workers (e.g. a Pi range-streaming
+            # a large MKV). Fall back to probing when it's absent or malformed.
+            _cmeta = chunk.get('stream_meta') if isinstance(chunk, dict) else None
+            _used_meta = False
+            if _cmeta and (_cmeta.get('audio_index') is not None or _cmeta.get('subtitle_indices')):
+                try:
+                    _ai = _cmeta.get('audio_index')
+                    audio_index = int(_ai) if _ai is not None else None
+                    subtitle_indices = [int(x) for x in (_cmeta.get('subtitle_indices') or [])]
+                    _mac = _cmeta.get('audio_channels')
+                    audio_channels = int(_mac) if _mac else 2
+                    _used_meta = True
+                    log(worker_id, "Using stream info from manager; skipping probe.")
+                except (TypeError, ValueError) as _cme:
+                    log(worker_id, f"Bad stream_meta from manager ({_cme}); probing locally.", "WARN")
+                    _used_meta = False
+
+            if not _used_meta:
+                update_status("Probing")
+                probe_data = None
+                for _pa in range(3):
+                    try:
+                        cmd_probe = ([FFPROBE_CMD] if _is_local else [FFPROBE_CMD, '-headers', ffmpeg_http_headers]) + \
+                                    ['-v', 'quiet', '-print_format', 'json', '-show_streams', '-show_format', dl_url]
+                        res = subprocess.run(cmd_probe, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                             encoding='utf-8', errors='replace', timeout=60)
+                        probe_data = json.loads(res.stdout)
                         break
-            for s in probe_data.get('streams', []):
-                if s['codec_type'] == 'subtitle':
-                    if s.get('codec_name', '').lower() in ['subrip', 'ass', 'webvtt', 'mov_text', 'text', 'srt', 'ssa']:
-                        subtitle_indices.append(s['index'])
+                    except Exception as _pe:
+                        if _pa < 2:
+                            time.sleep(5 * (_pa + 1))
+                        else:
+                            log(worker_id, f"Chunk probe failed: {_pe}", "ERROR")
+                if probe_data is None:
+                    report_chunk("failed", error_msg="FFprobe failed after 3 attempts")
+                    return
+
+                audio_streams = [s for s in probe_data.get('streams', []) if s['codec_type'] == 'audio']
+                if audio_streams:
+                    audio_index = audio_streams[0]['index']
+                    for s in audio_streams:
+                        if s.get('tags', {}).get('language', '').lower() in ['eng', 'en', 'english']:
+                            audio_index = s['index']; break
+                    for s in audio_streams:
+                        if s['index'] == audio_index:
+                            try: audio_channels = int(s.get('channels', 2))
+                            except: pass
+                            break
+                for s in probe_data.get('streams', []):
+                    if s['codec_type'] == 'subtitle':
+                        if s.get('codec_name', '').lower() in ['subrip', 'ass', 'webvtt', 'mov_text', 'text', 'srt', 'ssa']:
+                            subtitle_indices.append(s['index'])
+
             if audio_index is None and not subtitle_indices:
                 report_chunk("failed", error_msg="No audio or subtitle streams found")
                 return
@@ -2176,9 +2197,33 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                         # "pending" or "error" → server has no hash yet, proceed normally
                 # -------------------------------------------------------
 
-                update_status("Probing")
                 total_sec = 0; total_min = 0; audio_index = 0; subtitle_indices = []
-                for _probe_attempt in range(3):
+                meta_audio_channels = None
+                # If the manager already probed the source it hands us the stream
+                # layout, letting us skip the probe entirely — the slowest and
+                # most failure-prone step on constrained workers (e.g. a Pi
+                # range-streaming a large MKV over HTTP). Fall back to probing
+                # ourselves when it's absent (older manager / never chunk-probed).
+                _smeta = job.get('stream_meta') if isinstance(job, dict) else None
+                if _smeta and (_smeta.get('audio_index') is not None or _smeta.get('subtitle_indices')):
+                    try:
+                        total_sec = float(_smeta.get('duration') or 0)
+                        total_min = int(total_sec / 60)
+                        _ai = _smeta.get('audio_index')
+                        audio_index = int(_ai) if _ai is not None else 0
+                        subtitle_indices = [int(x) for x in (_smeta.get('subtitle_indices') or [])]
+                        _mac = _smeta.get('audio_channels')
+                        meta_audio_channels = int(_mac) if _mac else None
+                        probe_data = {"from_manager": True}
+                        log(worker_id, "Using stream info from manager; skipping probe.")
+                    except (TypeError, ValueError) as _sme:
+                        log(worker_id, f"Bad stream_meta from manager ({_sme}); probing locally.", "WARN")
+                        _smeta = None
+                else:
+                    _smeta = None
+                if not _smeta:
+                    update_status("Probing")
+                for _probe_attempt in ([] if _smeta else range(3)):
                     try:
                         if _is_local:
                             cmd_probe = [FFPROBE_CMD,
@@ -2259,12 +2304,15 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                 
                 # Robust Audio Downmixing (Prevents crashes on corrupt streams claiming 40+ channels)
                 audio_channels = 2 # Default assumption
-                try:
-                    for s in probe_data.get('streams', []):
-                        if s['index'] == audio_index:
-                            audio_channels = int(s.get('channels', 2))
-                            break
-                except: pass
+                if meta_audio_channels is not None:
+                    audio_channels = meta_audio_channels
+                else:
+                    try:
+                        for s in probe_data.get('streams', []):
+                            if s['index'] == audio_index:
+                                audio_channels = int(s.get('channels', 2))
+                                break
+                    except: pass
 
                 # AUDIO FILTER FIX (MONO + DIALOGUE FOCUS)
                 audio_filter = "aresample=async=1" 

--- a/worker_template.py
+++ b/worker_template.py
@@ -1459,7 +1459,10 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
             '-reconnect', '1', '-reconnect_streamed', '1',
             '-reconnect_delay_max', '60', '-reconnect_on_network_error', '1',
         ]
-        out_path = os.path.join(temp_dir, f"chunk_out{ENCODING_CONFIG['OUTPUT_EXT']}")
+        # Per-chunk output name: a leaked/killed ffmpeg from a previous chunk
+        # must never share an output path with the current one.
+        _co_safe = re.sub(r'[^a-zA-Z0-9_-]', '_', f"{job_id}_{kind}_{idx}")[:80]
+        out_path = os.path.join(temp_dir, f"chunk_out_{_co_safe}{ENCODING_CONFIG['OUTPUT_EXT']}")
         raw_log_path = os.path.join(temp_dir, "chunk_encode.log")
         gz_log_path = os.path.join(temp_dir, "chunk_encode.log.gz")
 
@@ -1500,15 +1503,21 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
             # a large MKV). Fall back to probing when it's absent or malformed.
             _cmeta = chunk.get('stream_meta') if isinstance(chunk, dict) else None
             _used_meta = False
-            if _cmeta and (_cmeta.get('audio_index') is not None or _cmeta.get('subtitle_indices')):
+            if _cmeta:
                 try:
                     _ai = _cmeta.get('audio_index')
-                    audio_index = int(_ai) if _ai is not None else None
-                    subtitle_indices = [int(x) for x in (_cmeta.get('subtitle_indices') or [])]
-                    _mac = _cmeta.get('audio_channels')
-                    audio_channels = int(_mac) if _mac else 2
-                    _used_meta = True
-                    log(worker_id, "Using stream info from manager; skipping probe.")
+                    _mac = int(_cmeta.get('audio_channels') or 0)
+                    _si = [int(x) for x in (_cmeta.get('subtitle_indices') or [])]
+                    # Usable only when complete: an audio track needs its channel
+                    # count (it selects the mono downmix formula — guessing 2 on
+                    # a 5.1 source would bury the dialogue), and a subs-only
+                    # source needs at least one subtitle index.
+                    if (_ai is not None and _mac >= 1) or (_ai is None and _si):
+                        audio_index = int(_ai) if _ai is not None else None
+                        subtitle_indices = _si
+                        audio_channels = _mac if _mac >= 1 else 2
+                        _used_meta = True
+                        log(worker_id, "Using stream info from manager; skipping probe.")
                 except (TypeError, ValueError) as _cme:
                     log(worker_id, f"Bad stream_meta from manager ({_cme}); probing locally.", "WARN")
                     _used_meta = False
@@ -1600,32 +1609,40 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
 
             last_rep = 0; last_pct = 0; last_hb = time.time()
             log_buffer = []
-            with open(raw_log_path, 'w', encoding='utf-8') as raw_log:
-                while True:
-                    if PAUSE_REQUESTED:
-                        if time.time() - last_hb > 30:
-                            report_chunk("processing", last_pct)
-                            last_hb = time.time()
-                        time.sleep(0.2)
-                        continue
-                    line = proc.stdout.readline()
-                    if line:
-                        log_buffer.append(line); log_buffer = log_buffer[-50:]
-                        raw_log.write(line); raw_log.flush()
-                    if not line and proc.poll() is not None: break
-                    if "out_time=" in line and "N/A" not in line and prog_total > 0:
-                        try:
-                            curr_sec = get_seconds(line.split('=')[1].strip())
-                            pct = min(100, int((curr_sec / prog_total) * 100))
-                            last_pct = pct
-                            if single_mode: print_progress(worker_id, curr_sec, prog_total, prefix='Enc')
-                            else: update_status(f"Enc {pct}%")
-                            if time.time() - last_rep > 10:
-                                report_chunk("processing", pct)
-                                last_rep = time.time(); last_hb = last_rep
-                        except: pass
-            with PROC_LOCK:
-                if worker_id in ACTIVE_PROCS: del ACTIVE_PROCS[worker_id]
+            # try/finally: an exception mid-loop (e.g. disk-full on the log
+            # write) must still deregister and kill ffmpeg — a leaked encoder
+            # blocks forever on a full stdout pipe once nobody reads it.
+            try:
+                with open(raw_log_path, 'w', encoding='utf-8') as raw_log:
+                    while True:
+                        if PAUSE_REQUESTED:
+                            if time.time() - last_hb > 30:
+                                report_chunk("processing", last_pct)
+                                last_hb = time.time()
+                            time.sleep(0.2)
+                            continue
+                        line = proc.stdout.readline()
+                        if line:
+                            log_buffer.append(line); log_buffer = log_buffer[-50:]
+                            raw_log.write(line); raw_log.flush()
+                        if not line and proc.poll() is not None: break
+                        if "out_time=" in line and "N/A" not in line and prog_total > 0:
+                            try:
+                                curr_sec = get_seconds(line.split('=')[1].strip())
+                                pct = min(100, int((curr_sec / prog_total) * 100))
+                                last_pct = pct
+                                if single_mode: print_progress(worker_id, curr_sec, prog_total, prefix='Enc')
+                                else: update_status(f"Enc {pct}%")
+                                if time.time() - last_rep > 10:
+                                    report_chunk("processing", pct)
+                                    last_rep = time.time(); last_hb = last_rep
+                            except: pass
+            finally:
+                with PROC_LOCK:
+                    if worker_id in ACTIVE_PROCS: del ACTIVE_PROCS[worker_id]
+                if proc.poll() is None:
+                    try: proc.kill()
+                    except Exception: pass
             if proc.returncode == 0 or SHUTDOWN_EVENT.is_set(): break
 
         def upload_chunk_log():
@@ -1673,7 +1690,10 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
         upload_ok = False
         upload_final = False  # 409/400: manager already resolved this chunk, don't re-report
         for up_attempt in range(3):
-            if SHUTDOWN_EVENT.is_set(): break
+            # Graceful drain ("Finish") must still deliver a finished encode —
+            # only the RETRIES are skipped on shutdown, so a dead network can't
+            # stall the exit for minutes.
+            if SHUTDOWN_EVENT.is_set() and up_attempt > 0: break
             try:
                 with open(out_path, 'rb') as f:
                     r = requests.post(f"{manager_url}/upload_chunk",
@@ -1986,7 +2006,10 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                 update_status("Up 0%")
                 _r_up_ok = False
                 for _r_up_att in range(3):
-                    if SHUTDOWN_EVENT.is_set(): break
+                    # A merged resume file is finished work — deliver it even
+                    # during a graceful drain (only retries are skipped), since
+                    # the cleanup below deletes it either way.
+                    if SHUTDOWN_EVENT.is_set() and _r_up_att > 0: break
                     try:
                         with open(_r_partial, 'rb') as _r_f:
                             _r_resp = requests.post(
@@ -2021,6 +2044,10 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                     try:
                         if os.path.exists(_fp): os.remove(_fp)
                     except: pass
+                # The resumed job is finished (one way or the other) — clear the
+                # id so a later pre-assignment exception can't be mis-reported
+                # against it (same guarantee as the per-iteration reset above).
+                job_id = None
             # ========================================================
 
             if check_version(manager_url):
@@ -2199,32 +2226,43 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
 
                 total_sec = 0; total_min = 0; audio_index = 0; subtitle_indices = []
                 meta_audio_channels = None
+                # Reset every job: a stale probe_data surviving from the previous
+                # loop iteration must never satisfy the failure check below.
+                probe_data = None
                 # If the manager already probed the source it hands us the stream
                 # layout, letting us skip the probe entirely — the slowest and
                 # most failure-prone step on constrained workers (e.g. a Pi
-                # range-streaming a large MKV over HTTP). Fall back to probing
-                # ourselves when it's absent (older manager / never chunk-probed).
+                # range-streaming a large MKV over HTTP). The shortcut needs the
+                # FULL layout (duration, a real audio track AND its channel
+                # count) because the whole-file command always maps audio and
+                # picks the downmix formula from the channel count — a partial
+                # blob must fall back to probing, not silently degrade.
                 _smeta = job.get('stream_meta') if isinstance(job, dict) else None
-                if _smeta and (_smeta.get('audio_index') is not None or _smeta.get('subtitle_indices')):
+                if _smeta:
                     try:
-                        total_sec = float(_smeta.get('duration') or 0)
-                        total_min = int(total_sec / 60)
+                        _s_dur = float(_smeta.get('duration') or 0)
                         _ai = _smeta.get('audio_index')
-                        audio_index = int(_ai) if _ai is not None else 0
-                        subtitle_indices = [int(x) for x in (_smeta.get('subtitle_indices') or [])]
-                        _mac = _smeta.get('audio_channels')
-                        meta_audio_channels = int(_mac) if _mac else None
-                        probe_data = {"from_manager": True}
-                        log(worker_id, "Using stream info from manager; skipping probe.")
+                        _mac = int(_smeta.get('audio_channels') or 0)
+                        if _s_dur > 0 and _ai is not None and _mac >= 1:
+                            total_sec = _s_dur; total_min = int(total_sec / 60)
+                            audio_index = int(_ai)
+                            subtitle_indices = [int(x) for x in (_smeta.get('subtitle_indices') or [])]
+                            meta_audio_channels = _mac
+                            probe_data = {"from_manager": True}
+                            log(worker_id, "Using stream info from manager; skipping probe.")
+                        else:
+                            _smeta = None  # incomplete blob → probe normally
                     except (TypeError, ValueError) as _sme:
                         log(worker_id, f"Bad stream_meta from manager ({_sme}); probing locally.", "WARN")
                         _smeta = None
-                else:
-                    _smeta = None
-                if not _smeta:
+                if probe_data is None:
                     update_status("Probing")
-                for _probe_attempt in ([] if _smeta else range(3)):
+                for _probe_attempt in ([] if probe_data else range(3)):
                     try:
+                        # Start each attempt clean so a partially-parsed failure
+                        # can't leave duplicate subtitle maps or a half-set state.
+                        probe_data = None
+                        audio_index = 0; subtitle_indices = []
                         if _is_local:
                             cmd_probe = [FFPROBE_CMD,
                                 '-v', 'quiet', '-print_format', 'json', '-show_streams', '-show_format', dl_url]
@@ -2233,20 +2271,21 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                                 '-headers', ffmpeg_http_headers,
                                 '-v', 'quiet', '-print_format', 'json', '-show_streams', '-show_format', dl_url]
                         res = subprocess.run(cmd_probe, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8', errors='replace', timeout=60)
-                        probe_data = json.loads(res.stdout)
-                        dur = probe_data.get('format', {}).get('duration')
+                        _pd = json.loads(res.stdout)
+                        dur = _pd.get('format', {}).get('duration')
                         if dur: total_sec = float(dur); total_min = int(total_sec / 60)
 
-                        audio_streams = [s for s in probe_data.get('streams', []) if s['codec_type'] == 'audio']
+                        audio_streams = [s for s in _pd.get('streams', []) if s['codec_type'] == 'audio']
                         if audio_streams:
                             audio_index = audio_streams[0]['index']
                             for s in audio_streams:
                                 if s.get('tags', {}).get('language', '').lower() in ['eng', 'en', 'english']:
                                     audio_index = s['index']; break
-                        for s in probe_data.get('streams', []):
+                        for s in _pd.get('streams', []):
                             if s['codec_type'] == 'subtitle':
                                 if s.get('codec_name', '').lower() in ['subrip', 'ass', 'webvtt', 'mov_text', 'text', 'srt', 'ssa']:
                                     subtitle_indices.append(s['index'])
+                        probe_data = _pd  # only assigned once fully parsed
                         break  # probe succeeded
                     except Exception as _probe_err:
                         if _probe_attempt < 2:
@@ -2255,7 +2294,7 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                         else:
                             log(worker_id, f"Probe failed after 3 attempts: {_probe_err}. Skipping job.", "ERROR")
 
-                if 'probe_data' not in locals():
+                if probe_data is None:
                     post_status("failed", error_msg="FFprobe failed after 3 attempts")
                     report_error(job_id, "probe_failure", "FFprobe failed after 3 attempts")
                     continue
@@ -2387,6 +2426,8 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                 })
 
                 proc = None; enc_time = 0
+                log_buffer = []  # defined before the loop: a pre-first-attempt
+                                 # shutdown must not NameError the failure dump
                 for _enc_attempt in range(3):
                     if SHUTDOWN_EVENT.is_set(): break
                     if _enc_attempt > 0:
@@ -2422,44 +2463,54 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                         lambda: post_status("paused" if PAUSE_REQUESTED else "processing", _hb["pct"]))
 
                     raw_log_path = os.path.join(temp_dir, "encode.log")
-                    with open(raw_log_path, 'w', encoding='utf-8') as raw_log:
-                        while True:
-                            if PAUSE_REQUESTED:
-                                _now = time.time()
-                                if _now - last_hb > 30:
-                                    post_status("paused", last_enc_pct)
-                                    last_hb = _now
-                                time.sleep(0.2)
-                                continue
+                    # try/finally: an exception mid-loop (e.g. disk-full on the
+                    # log write) must still stop the heartbeat thread — which
+                    # would otherwise post "processing" forever, contradicting
+                    # the "failed" status the outer handler reports — and must
+                    # kill ffmpeg, which would otherwise block on a full pipe
+                    # once nobody reads its stdout.
+                    try:
+                        with open(raw_log_path, 'w', encoding='utf-8') as raw_log:
+                            while True:
+                                if PAUSE_REQUESTED:
+                                    _now = time.time()
+                                    if _now - last_hb > 30:
+                                        post_status("paused", last_enc_pct)
+                                        last_hb = _now
+                                    time.sleep(0.2)
+                                    continue
 
-                            line = proc.stdout.readline()
-                            if line:
-                                log_buffer.append(line); log_buffer = log_buffer[-50:]
-                                raw_log.write(line)
-                                raw_log.flush()
+                                line = proc.stdout.readline()
+                                if line:
+                                    log_buffer.append(line); log_buffer = log_buffer[-50:]
+                                    raw_log.write(line)
+                                    raw_log.flush()
 
-                            if not line and proc.poll() is not None: break
+                                if not line and proc.poll() is not None: break
 
-                            if "out_time=" in line and "N/A" not in line and total_sec > 0:
-                                try:
-                                    time_str = line.split('=')[1].strip()
-                                    curr_sec = get_seconds(time_str)
-                                    pct = min(100, int((curr_sec/total_sec)*100))
-                                    last_enc_pct = pct
-                                    _hb["pct"] = pct
+                                if "out_time=" in line and "N/A" not in line and total_sec > 0:
+                                    try:
+                                        time_str = line.split('=')[1].strip()
+                                        curr_sec = get_seconds(time_str)
+                                        pct = min(100, int((curr_sec/total_sec)*100))
+                                        last_enc_pct = pct
+                                        _hb["pct"] = pct
 
-                                    if single_mode: print_progress(worker_id, curr_sec, total_sec, prefix='Enc')
-                                    else: update_status(f"Enc {pct}%")
+                                        if single_mode: print_progress(worker_id, curr_sec, total_sec, prefix='Enc')
+                                        else: update_status(f"Enc {pct}%")
 
-                                    if time.time() - last_rep > 10:
-                                        post_status("processing", pct)
-                                        last_rep = time.time()
-                                        last_hb = last_rep
-                                except: pass
-
-                    _hb_stop.set()
-                    with PROC_LOCK:
-                        if worker_id in ACTIVE_PROCS: del ACTIVE_PROCS[worker_id]
+                                        if time.time() - last_rep > 10:
+                                            post_status("processing", pct)
+                                            last_rep = time.time()
+                                            last_hb = last_rep
+                                    except: pass
+                    finally:
+                        _hb_stop.set()
+                        with PROC_LOCK:
+                            if worker_id in ACTIVE_PROCS: del ACTIVE_PROCS[worker_id]
+                        if proc.poll() is None:
+                            try: proc.kill()
+                            except Exception: pass
 
                     enc_time = time.time() - start_enc
                     if proc.returncode == 0 or SHUTDOWN_EVENT.is_set(): break
@@ -2519,6 +2570,7 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
 
                     # RETRY LOOP for Uploads
                     upload_success = False
+                    upload_final = False  # 409/400: manager already resolved the job — don't re-send or re-report
                     for up_attempt in range(3):
                         try:
                             with ProgressFileReader(local_dst, upload_cb) as f:
@@ -2531,8 +2583,23 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                                 if r.status_code == 200:
                                     upload_success = True
                                     break
+                                elif r.status_code == 409:
+                                    # Job was reset/chunked/completed elsewhere while we
+                                    # encoded — the manager no longer wants this file.
+                                    log(worker_id, "Job no longer accepts a whole-file upload (reassigned). Dropping.", "WARN")
+                                    upload_final = True; break
+                                elif r.status_code == 400:
+                                    # Failed manager-side verification; the manager has
+                                    # already registered the failure. Re-sending the
+                                    # same file twice more can't change the verdict.
+                                    _msg = ""
+                                    try: _msg = r.json().get('message', '')
+                                    except: pass
+                                    log(worker_id, f"Upload rejected by manager: {_msg}", "WARN")
+                                    upload_final = True; break
                                 else:
                                     log(worker_id, f"Upload rejected by server: {r.status_code}", "WARN")
+                                    time.sleep(10)
                         except Exception as e:
                             log(worker_id, f"Upload attempt {up_attempt+1} failed/timed out: {e}", "WARN")
                             time.sleep(10) # Wait 10s before retry
@@ -2552,6 +2619,12 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                             _done_chk = os.path.join(temp_dir, f"{_RESUME_CHK_PREFIX}{re.sub(r'[^a-zA-Z0-9_-]', '_', str(job_id))}.json")
                             if os.path.exists(_done_chk): os.remove(_done_chk)
                         except: pass
+                        upload_encode_log()
+                    elif upload_final:
+                        # Manager already resolved the job (409/400) — its state
+                        # is authoritative; a "failed" report here would clobber it.
+                        d = WORKER_DETAILS.get(worker_id)
+                        if d is not None: d["phase"] = "Done"
                         upload_encode_log()
                     else:
                         d = WORKER_DETAILS.get(worker_id)


### PR DESCRIPTION
Two pieces of work on one branch: the stream-layout ("skip the probe") feature, and the results of a full-program audit run after all the recent additions.

## 1. Hand workers the source stream layout (skip probing)

Probing the source is the slowest, most fragile step on constrained workers — a Raspberry Pi range-streaming a large MKV over HTTP can sit on "Probe" for minutes. The manager already probes each source when planning a chunk split; it now records the stream layout (chosen audio track, channel count, subtitle indices, duration) in an additive `stream_meta` column and hands it to workers with whole-file jobs and audio chunks. Workers use it and skip `ffprobe` entirely, falling back to probing when it's absent or incomplete. Fully backward compatible; worker bumped to **3.4.0**.

## 2. Audit fixes

**Manager — correctness & robustness**
- **Queue-wedge fix:** `/get_chunk` no longer splits a fresh queued job when pending chunks exist that a capped (browser) worker merely can't take. Previously each browser poll converted one more queued job into a wedged chunked job. Also `_plan_chunks` now uses ceil so no chunk ever exceeds `CHUNK_DURATION_SEC` — a default browser (120s cap) can actually take default chunks (a 290s video used to produce two 145s chunks no browser could accept).
- **RAM-mode WAL safety:** startup removes stale `/dev/shm` `-wal`/`-shm` sidecars before the disk→RAM copy (stale-WAL replay is a documented SQLite corruption vector) and counts the `-wal` mtime when deciding which copy is newer.
- Malformed `max_chunk_sec` no longer 500s every `/get_chunk` request.
- `/upload_log` bounds the decompressed read to 16 MB (a 50 MB gzip bomb otherwise inflates to multi-GB in the single gunicorn worker) and re-checks the file size on disk.
- `upload_result` credits a FractumCoin earning only when the completion UPDATE actually took effect (no double payout when a job was reset + re-split during the slow verify).
- The split revert path no longer NULLs a cached `source_duration_sec`.
- `segment_url` is relative — the absolute `SERVER_URL_DISPLAY` form broke browser chunk downloads under COEP when `/web` was opened via LAN IP or localhost.

**Worker (3.4.0)**
- `probe_data` reset per job: a stale probe from the previous iteration could defeat the probe-failure check and encode with the wrong stream layout.
- Encode loops got try/finally: exceptions now stop the heartbeat thread (which otherwise posted "processing" forever against a failed job) and kill the leaked ffmpeg; chunk outputs use per-chunk filenames.
- `stream_meta` shortcut requires the complete layout — partial blobs fall back to probing instead of silently mis-downmixing 5.1 audio or reporting 0% progress.
- Graceful drain ("Finish") now delivers finished chunk/resume uploads instead of discarding completed encodes; whole-file uploads treat 409/400 as terminal like the chunk path.
- `job_id` cleared after a resume (no mis-reported failures against a finished job); `log_buffer` initialized before the attempt loop (NameError on early shutdown).

**Browser worker (3.4.0)**
- Sends `worker_id` on `/get_chunk` and `/get_job` — assignments were recorded with NULL, so stop-time releases matched nothing and abandoned work sat assigned for the 30-min/4-h sweeps.
- Reports encode failures (so the 3-strikes whole-file fallback engages on wasm OOMs) and sends heartbeats on whole-file jobs (slow encodes were requeued and done twice).
- Whole-file encodes honor the `live_action` profile (CRF 57) and use the target 24k audio bitrate (was CRF 63 / 12k hardcoded); dropped the `tune=0` override so browser chunks match native chunks when tiled. Kept the built-in opus encoder because the **deployed** wasm was configured without `--enable-libopus` (verified via the binary's embedded configure line); the saved wasm-build recipe enables it for the next rebuild.

**Utilities/docs**
- `find_truncated.py`: an unreadable output lands in "undetermined" instead of TRUNCATED (an ffprobe-less box would have re-queued the entire completed library with `--requeue`); report lists fixed.
- Removed the dead `RATE_LIMIT_JOBS_PER_HOUR` config key; README chunk-duration claims match the shipped config.

## Compatibility

No encoding-target changes (SVT-AV1 preset 2, CRF 63/57, 480p, Opus mono 24k untouched — the browser 12k audio was a deviation that's now corrected *to* the target). All DB changes additive; a running queue survives the update.

## Testing

- All Python compiles; `node --check` on web_node.js passes.
- Manager booted with a test client: malformed `max_chunk_sec` returns 200/empty (was 500), `/get_job` + `/api/stats` fine, `_plan_chunks(290s)` → 3 chunks ≤ 97s (was 2 × 145s), 200 MB gzip bomb reads capped at 16 MB.
- `find_truncated.py` on a garbage output file → "undetermined", 0 re-encodes (was TRUNCATED → re-queue).
- Multi-track MKV (jpn 2ch + eng 5.1 + SRT): manager stream selection matches the worker's exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)