### PR TITLE
Send worker token on all manager requests to the remote source (enables edge bot-blocking)

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -543,7 +543,13 @@ def _probe_media(src, timeout=60):
     or None on failure."""
     try:
         cmd = ['ffprobe', '-v', 'error', '-print_format', 'json',
-               '-show_streams', '-show_format', src]
+               '-show_streams', '-show_format']
+        # Remote sources may sit behind an edge/WAF rule that blocks any
+        # request without the worker token (bot protection on an otherwise
+        # open directory) — authenticate exactly like the workers do.
+        if WORKER_SECRET and isinstance(src, str) and src.startswith(('http://', 'https://')):
+            cmd += ['-headers', f'X-Worker-Token: {WORKER_SECRET}\r\n']
+        cmd.append(src)
         res = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         if res.returncode != 0:
             return None
@@ -1171,6 +1177,11 @@ def scan_remote_http(url, prefix="", depth=0, known_ids=None):
     if depth > 10: return # Prevent infinite recursion
 
     headers = {'User-Agent': 'FractumManager/1.0'}
+    # Send the worker token like every other consumer of the remote source, so
+    # an edge/WAF rule on that host ("no token → block") can shut out scraper
+    # bots without breaking the scan.
+    if WORKER_SECRET:
+        headers['X-Worker-Token'] = WORKER_SECRET
     
     # Retry Loop & Increased Timeout
     r = None


### PR DESCRIPTION
## Purpose

Lets the remote source host (the open directory) sit behind a simple edge/WAF rule — **"no `X-Worker-Token` header → block"** — to shut out scraper bots, without breaking any part of the encoding pipeline.

## Change

Two manager-side consumers of the remote source were the only ones not authenticating:

- **`scan_remote_http`** — directory-listing GETs and per-file HEAD requests now send `X-Worker-Token` (one headers dict covers both).
- **`_probe_media`** — the chunk-split probe and duration checks now pass `-headers 'X-Worker-Token: …'` to ffprobe for `http(s)` sources (local paths unchanged).

Everything else already sent it: native workers (ffmpeg streaming + quota HEAD), `/download_segment`, `/download_media` proxy, and `find_truncated.py`. Browser workers never contact the source host directly.

## Testing

Ran a mock "edge gate" HTTP server that 403s any request without the correct `X-Worker-Token` (exactly what a Cloudflare WAF custom rule will do), pointed `REMOTE_SOURCE_URL` at it, and verified:
- untokened request → 403, tokened → 200 (gate works)
- the manager's startup scan discovered the remote file through the gate
- `_probe_media` successfully probed the token-gated source (duration + stream layout returned)

No encoding-target changes; no DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_