### PR TITLE
Fix chunk encodes failing on ffmpeg 7.x (SVT-AV1 240 fps cap)

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -595,7 +595,7 @@ def _probe_media(src, timeout=60):
 
         # Frame-rate info of the first video stream — chunk boundaries must be
         # snapped to the frame grid, which is only well-defined for CFR sources.
-        fps = 0.0; start_time = 0.0; is_cfr = False
+        fps = 0.0; start_time = 0.0; is_cfr = False; fps_rational = None
         video = next((s for s in streams if s.get('codec_type') == 'video'), None)
         if video:
             r_rate = _parse_rate(video.get('r_frame_rate', '0/1'))
@@ -603,11 +603,17 @@ def _probe_media(src, timeout=60):
             try: start_time = float(video.get('start_time') or 0)
             except (TypeError, ValueError): start_time = 0.0
             fps = r_rate
+            # Exact fraction (e.g. "24000/1001") — handed to chunk workers so
+            # they can pin the encoder time base (see stream_meta 'fps').
+            _rr = str(video.get('r_frame_rate') or '')
+            if re.fullmatch(r'[1-9]\d*/[1-9]\d*', _rr):
+                fps_rational = _rr
             # CFR when the container's average rate agrees with the nominal rate
             is_cfr = (r_rate > 0 and avg_rate > 0 and abs(r_rate - avg_rate) / r_rate < 0.005)
         return {
             "duration": dur, "has_audio": has_audio, "has_subs": has_subs,
             "fps": fps, "start_time": start_time, "cfr": is_cfr,
+            "fps_rational": fps_rational,
             "format_start": format_start, "audio_start": audio_start,
             "audio_index": audio_index, "audio_channels": audio_channels,
             "subtitle_indices": subtitle_indices,
@@ -627,6 +633,12 @@ def _stream_meta_json(probe):
             "audio_index": probe.get("audio_index"),
             "audio_channels": probe.get("audio_channels") or 2,
             "subtitle_indices": probe.get("subtitle_indices") or [],
+            # Exact frame rate fraction ("24000/1001"). Chunk workers pin the
+            # encoder time base with it: ffmpeg 7.x doesn't propagate a frame
+            # rate through setpts with -fps_mode passthrough, so libsvtav1
+            # falls back to 1/time_base (1000 fps on MKV) and refuses to start
+            # ("The maximum allowed frame rate is 240 fps").
+            "fps": probe.get("fps_rational"),
         })
     except (TypeError, ValueError):
         return None
@@ -809,7 +821,11 @@ def _split_claimed_job(job):
     # workers give up waiting after ~30s.
     probe = _probe_media(src, timeout=20) if src else None
     ranges = None
-    if probe and probe['cfr']:
+    if probe and probe['fps'] > 240:
+        # SVT-AV1 caps at 240 fps — a "faster" rate is broken container
+        # metadata, and the frame-grid boundary math would be wrong anyway.
+        log_event("INFO", f"Frame rate {probe['fps']:.0f} fps out of range — encoding whole.", job_id)
+    elif probe and probe['cfr']:
         # Streams that don't share a common start offset (e.g. broadcast
         # captures where audio leads video) can't be sliced on the video
         # frame grid without shifting A/V sync — encode those whole.
@@ -921,11 +937,17 @@ def _assign_pending_chunk(worker_id, folder_filter, max_size_mb, video_only=Fals
                 return None
             chunk = dict(row)
             # Only the audio chunk probes the source; hand it the pre-computed
-            # stream layout so it can skip that probe. Video chunks don't need
-            # it — drop it to keep the payload small.
+            # stream layout so it can skip that probe. Video chunks only need
+            # the frame rate (they pin the encoder time base with it) — drop
+            # the rest to keep the payload small.
             _sm = chunk.pop('stream_meta', None)
-            if chunk['kind'] == 'audio' and _sm:
-                try: chunk['stream_meta'] = json.loads(_sm)
+            if _sm:
+                try:
+                    _sm_parsed = json.loads(_sm)
+                    if chunk['kind'] == 'audio':
+                        chunk['stream_meta'] = _sm_parsed
+                    elif _sm_parsed.get('fps'):
+                        chunk['fps'] = _sm_parsed['fps']
                 except (TypeError, ValueError): pass
             # The final video chunk encodes to EOF instead of using -t.
             # Computed as a separate single-row query so the assignment scan

--- a/static/web_node.js
+++ b/static/web_node.js
@@ -165,6 +165,16 @@ async function processChunk(chunk) {
         // lp=1 only limits encoder threading (browser memory), it does not
         // change the bitstream — no tune override, so browser chunks match
         // native chunks (SVT default tune) when tiled into one video.
+        // -enc_time_base pins the encoder time base to the source frame rate
+        // (manager sends the exact fraction): FFmpeg 7.x (this wasm) doesn't
+        // propagate a frame rate through setpts, and libsvtav1 would see
+        // 1/time_base = 1000 fps and refuse to start (240 fps cap).
+        let etbArgs = [];
+        const frMatch = String(chunk.fps || '').match(/^([1-9]\d*)\/([1-9]\d*)$/);
+        if (frMatch) {
+            const fn = parseInt(frMatch[1], 10), fd = parseInt(frMatch[2], 10);
+            if (fn / fd <= 240) etbArgs = ['-enc_time_base', `${fd}/${fn}`];
+        }
         const args = [
             '-threads', '1', '-v', 'verbose',
             '-ss', lead.toFixed(3), '-i', segPath, '-t', dur.toFixed(3),
@@ -172,6 +182,7 @@ async function processChunk(chunk) {
             '-c:v', 'libsvtav1', '-preset', '2', '-crf', crf,
             '-pix_fmt', 'yuv420p',
             '-svtav1-params', 'lp=1',
+            ...etbArgs,
             '-vf', 'setpts=PTS-STARTPTS,scale=-2:480',
             '-movflags', '+faststart',
             outPath

--- a/templates/web_worker.html
+++ b/templates/web_worker.html
@@ -238,7 +238,7 @@
     let currentChunk = null;   // {job_id, chunk_index} of an in-flight chunk, for release + heartbeat
 
     // Must be >= manager MIN_CLIENT_VERSION or /get_job returns "Update Required".
-    const WEB_WORKER_VERSION = "3.4.0";
+    const WEB_WORKER_VERSION = "3.4.1";
 
     // Worker token: injected by the manager (/web) so the page authenticates
     // out of the box; ?token= in the URL overrides. Empty only if the manager

--- a/worker_template.py
+++ b/worker_template.py
@@ -113,7 +113,7 @@ except ImportError as _e:
 DEFAULT_MANAGER_URL = "https://encode.fractumseraph.net/"
 DEFAULT_USERNAME = "Anonymous"
 DEFAULT_WORKERNAME = f"Node-{int(time.time())}"
-WORKER_VERSION = "3.4.0"
+WORKER_VERSION = "3.4.1"
 WORKER_SECRET = os.environ.get("WORKER_SECRET", "DefaultInsecureSecret")
 
 SHUTDOWN_EVENT = threading.Event()
@@ -1482,6 +1482,20 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
             is_last = bool(chunk.get('is_last'))
             seek_flags = ['-ss', f"{start_sec:.5f}"] if start_sec > 0 else []
             limit_flags = [] if is_last else ['-t', f"{dur_sec:.5f}"]  # last chunk runs to EOF
+            # Pin the encoder time base to the source frame rate (manager sends
+            # the exact fraction, e.g. "24000/1001"). Without this, ffmpeg 7.x
+            # doesn't propagate a frame rate through setpts under -fps_mode
+            # passthrough, so libsvtav1 falls back to 1/time_base — 1000 fps on
+            # an MKV source — and refuses to start ("The maximum allowed frame
+            # rate is 240 fps"). Verified: output timestamps are bit-identical
+            # with and without this flag on ffmpeg 6.x.
+            etb_flags = []
+            _fr = str(chunk.get('fps') or '')
+            _m = re.fullmatch(r'([1-9]\d*)/([1-9]\d*)', _fr)
+            if _m:
+                _fn, _fd = int(_m.group(1)), int(_m.group(2))
+                if 0 < _fn / _fd <= 240:
+                    etb_flags = ['-enc_time_base', f"{_fd}/{_fn}"]
             cmd = ([FFMPEG_CMD] + input_flags + seek_flags +
                    ['-y', '-i', dl_url] + limit_flags +
                    ['-map', '0:v:0', '-an', '-sn',
@@ -1489,8 +1503,8 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                     '-c:v', ENCODING_CONFIG["VIDEO_CODEC"],
                     '-preset', ENCODING_CONFIG["VIDEO_PRESET"],
                     '-crf', str(target_crf),
-                    '-pix_fmt', ENCODING_CONFIG["VIDEO_PIX_FMT"],
-                    '-vf', f"setpts=PTS-STARTPTS,{ENCODING_CONFIG['VIDEO_SCALE']}",
+                    '-pix_fmt', ENCODING_CONFIG["VIDEO_PIX_FMT"]] + etb_flags +
+                   ['-vf', f"setpts=PTS-STARTPTS,{ENCODING_CONFIG['VIDEO_SCALE']}",
                     '-movflags', 'frag_keyframe+empty_moov+default_base_moof',
                     '-progress', 'pipe:1', out_path])
             prog_total = dur_sec


### PR DESCRIPTION
## Problem

Chunk video encodes fail at encoder init on ffmpeg **7.x** workers (Raspberry Pi OS / Debian 13 ships 7.1; the browser wasm is also 7.1):

```
Svt[error]: Instance 1: The maximum allowed frame rate is 240 fps
[libsvtav1] Error setting encoder parameters: bad parameter (0x80001005)
```

The source file is completely normal (verified: 23.976 fps CFR). The mechanism, reproduced with a frame-rate litmus encoder: `setpts=PTS-STARTPTS` clears the filter-chain frame rate, and under `-fps_mode passthrough` ffmpeg 7.x no longer falls back to the input stream's rate — the encoder receives `1/time_base` instead, which for an MKV source is **1000 fps**, over SVT-AV1's 240 cap. ffmpeg 6.1 is immune (verified). Every MKV-sourced chunk fails this way on a 7.x worker, burning fail counts until the whole-file fallback rescues the job.

## Fix

The manager already probes the exact frame rate when planning a split. It now records the rational fraction (`"24000/1001"`) in `stream_meta` and attaches it to every video chunk as `fps`. Native workers (**3.4.1**) and the browser worker pin the encoder time base with `-enc_time_base 1001/24000` — giving libsvtav1 the correct rate without touching timestamps.

Also: the manager refuses to chunk sources whose metadata claims >240 fps (broken metadata — SVT can't encode them and the boundary math would be wrong); those encode whole.

## Why `-enc_time_base` and not something else

- `-r` output option: **rejected by ffmpeg 7.x** together with `-fps_mode passthrough` ("This is contradictory").
- Removing `setpts` (framerate then flows through `scale`): tested and **rejected** — the seek residue shortens chunk container durations by exactly one frame, and the concat timeline breaks (278 timing defects across a 3-chunk join vs 0 with setpts).

## Verification

- Frame-rate litmus (an encoder that validates fps) on ffmpeg 7.0.2: fails with 1000/1 fps without the flag, passes with it; 6.1 passes either way.
- Output timestamps are **bit-identical** to current 6.1 output (same frame count, same pts on every frame) — mixed 6.1/7.x swarms tile cleanly at assembly.
- 3-chunk split + lossless concat: 720/720 frames, zero non-uniform frame intervals, exact durations.
- End-to-end with the real manager: split delivers `fps` on the chunk payload; the exact worker-built command encodes successfully.

## Compatibility

No encoding-target changes (the time base is container/init metadata, not bitstream tuning). Chunks split **before** this update lack the `fps` field — a 7.x worker still fails those, bounded by the existing 3-strikes → whole-file fallback (unaffected: that path has no `setpts`). All new splits carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_