### PR TITLE
Pin FFmpeg to 7.1 + require it at startup; truncation self-check; manager auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,22 @@ python3 find_truncated.py --include-missing  # also re-encode jobs with no outpu
 ### `update.sh` / `update.ps1`
 Pulls the latest code from git and restarts the service. Run on the manager host.
 
+### Built-in auto-update (no scripts needed)
+Set `MANAGER_AUTO_UPDATE = True` in `config.py` and the manager keeps itself
+current: every `MANAGER_UPDATE_INTERVAL_HOURS` it fetches
+`origin/MANAGER_UPDATE_BRANCH`, fast-forwards to it, refreshes
+`requirements.txt` dependencies, syncs/backs up the database, and restarts
+into the new code — via `MANAGER_RESTART_CMD` if you set one, otherwise a
+zero-downtime gunicorn reload (SIGHUP), otherwise a clean exit under systemd
+(`Restart=always` relaunches it). A repo with local modifications is left
+alone, and diverged history is reported instead of force-reset. Security
+note: whoever can push to that branch controls the server — protect it.
+
+**Worker FFmpeg requirements:** workers require FFmpeg **7.1+** with
+`libsvtav1` at startup. Older or unsuitable system installs are ignored and a
+pinned stable 7.1 build (BtbN release branch) is downloaded instead; git dev
+snapshots print a warning (unreleased builds have produced broken uploads).
+
 ---
 
 ## Architecture Overview

--- a/config.py.example
+++ b/config.py.example
@@ -39,6 +39,24 @@ DB_BACKUP_INTERVAL_HOURS = 12
 DB_BACKUP_RETENTION = 10
 
 # ==============================================================================
+# MANAGER AUTO-UPDATE
+# ==============================================================================
+# When True, the manager checks origin/<branch> on a schedule, fast-forwards
+# to it, and restarts itself into the new code — no manual login/pull/restart.
+# Restart order: MANAGER_RESTART_CMD if set; else a graceful gunicorn reload
+# (SIGHUP to the master, zero downtime); else a clean exit under systemd
+# (the shipped unit has Restart=always). Repos with local modifications are
+# never touched, and only fast-forward pulls are performed.
+# NOTE: this executes whatever lands on the branch — anyone with push access
+# to it effectively controls the server. Keep the branch protected.
+MANAGER_AUTO_UPDATE = True
+MANAGER_UPDATE_INTERVAL_HOURS = 6
+MANAGER_UPDATE_BRANCH = "main"
+# Optional explicit restart command, e.g.:
+# MANAGER_RESTART_CMD = "systemctl --user restart distributed-encodes.service"
+MANAGER_RESTART_CMD = None
+
+# ==============================================================================
 # FILE & DIRECTORY SETTINGS
 # ==============================================================================
 # Local folder to scan for source files

--- a/manager.py
+++ b/manager.py
@@ -1,6 +1,8 @@
 import os
+import sys
 import math
 import time
+import signal
 import threading
 import contextlib
 import sqlite3
@@ -112,6 +114,25 @@ try:
         from config import DB_BACKUP_RETENTION
     except ImportError:
         DB_BACKUP_RETENTION = 10
+
+    # Self-update from git: pull origin/<branch> on a schedule and restart
+    # into the new code, so updates don't need a manual login+pull+restart.
+    try:
+        from config import MANAGER_AUTO_UPDATE
+    except ImportError:
+        MANAGER_AUTO_UPDATE = False
+    try:
+        from config import MANAGER_UPDATE_INTERVAL_HOURS
+    except ImportError:
+        MANAGER_UPDATE_INTERVAL_HOURS = 6
+    try:
+        from config import MANAGER_UPDATE_BRANCH
+    except ImportError:
+        MANAGER_UPDATE_BRANCH = "main"
+    try:
+        from config import MANAGER_RESTART_CMD
+    except ImportError:
+        MANAGER_RESTART_CMD = None
 
 except ImportError:
     print("[!] Critical Error: config.py not found.")
@@ -327,6 +348,108 @@ def _backup_loop():
     while True:
         backup_database()
         time.sleep(interval)
+
+# ==============================================================================
+# MANAGER SELF-UPDATE (git pull + restart)
+# ==============================================================================
+
+_REPO_DIR = os.path.dirname(os.path.abspath(__file__))
+
+def _git(*args, timeout=180):
+    return subprocess.run(['git'] + list(args), cwd=_REPO_DIR,
+                          capture_output=True, text=True, timeout=timeout)
+
+def _restart_self():
+    """Restart the manager so the freshly pulled code takes effect.
+    Returns True when a restart was initiated. Tried in order:
+      1. MANAGER_RESTART_CMD from config (e.g. 'systemctl --user restart ...').
+      2. Running under gunicorn: SIGHUP the master — a graceful, zero-downtime
+         reload that re-execs the workers with the new code.
+      3. Running under systemd (Restart=always in the shipped unit): exit
+         cleanly and let systemd bring the new version up.
+    A bare `python manager.py` in a terminal has no safe restart path — we
+    keep running on the old code and say so rather than kill the service."""
+    if MANAGER_RESTART_CMD:
+        try:
+            subprocess.Popen(MANAGER_RESTART_CMD, shell=True)
+            return True
+        except Exception as e:
+            log_event("ERROR", f"Auto-update: restart command failed: {e}")
+            return False
+    try:
+        ppid = os.getppid()
+        with open(f'/proc/{ppid}/cmdline', 'rb') as f:
+            if b'gunicorn' in f.read():
+                os.kill(ppid, signal.SIGHUP)
+                return True
+    except Exception:
+        pass
+    # Under systemd, our DIRECT parent is the systemd instance (system or
+    # --user). Checking the parent's process name (not just INVOCATION_ID,
+    # which children of a service inherit into shells) avoids killing a
+    # manager someone launched by hand in a terminal.
+    try:
+        if os.environ.get('INVOCATION_ID'):
+            with open(f'/proc/{os.getppid()}/comm') as f:
+                if f.read().strip() == 'systemd':
+                    # Small delay so the HTTP response / log write finishes first.
+                    threading.Thread(target=lambda: (time.sleep(2), os._exit(0)), daemon=True).start()
+                    return True
+    except Exception:
+        pass
+    return False
+
+def _auto_update_loop():
+    """Periodically fast-forward to origin/<branch> and restart into it.
+    Never touches a repo with local (tracked) modifications, and only ever
+    fast-forwards — a diverged history is reported, not force-reset."""
+    interval = max(1, int(MANAGER_UPDATE_INTERVAL_HOURS)) * 3600
+    branch = MANAGER_UPDATE_BRANCH
+    while True:
+        time.sleep(interval)
+        try:
+            if _git('fetch', 'origin', branch).returncode != 0:
+                continue  # network/remote hiccup — try again next cycle
+            local  = _git('rev-parse', 'HEAD').stdout.strip()
+            remote = _git('rev-parse', f'origin/{branch}').stdout.strip()
+            if not local or not remote or local == remote:
+                continue
+            if _git('status', '--porcelain', '--untracked-files=no').stdout.strip():
+                log_event("WARN", "Auto-update skipped: repo has local modifications.")
+                continue
+            pull = _git('pull', '--ff-only', 'origin', branch)
+            if pull.returncode != 0:
+                log_event("ERROR", f"Auto-update pull failed: {(pull.stderr or '')[-300:]}")
+                continue
+            log_event("WARN", f"Auto-update: {local[:7]} -> {remote[:7]} from origin/{branch}.")
+            # Best-effort dependency refresh, mirroring update.sh
+            req = os.path.join(_REPO_DIR, 'requirements.txt')
+            if os.path.exists(req):
+                try:
+                    subprocess.run([sys.executable, '-m', 'pip', 'install', '-q', '-r', req],
+                                   capture_output=True, timeout=600)
+                except Exception:
+                    pass
+            # Make the DB safe before the process goes away.
+            try:
+                db_handler.sync_to_disk()
+            except Exception:
+                pass
+            if DB_BACKUP_ENABLED:
+                try:
+                    backup_database()
+                except Exception:
+                    pass
+            if _restart_self():
+                log_event("WARN", "Auto-update: restarting into the new version.")
+            else:
+                log_event("WARN", "Auto-update: new code pulled, but no automatic restart "
+                                  "path is available — restart the manager to apply it.")
+        except Exception as e:
+            try:
+                log_event("ERROR", f"Auto-update error: {e}")
+            except Exception:
+                pass
 
 # ==============================================================================
 # LOGGING
@@ -2973,6 +3096,9 @@ threading.Thread(target=scan_and_queue, daemon=True).start()
 threading.Thread(target=maintenance_loop, daemon=True).start()
 if DB_BACKUP_ENABLED:
     threading.Thread(target=_backup_loop, daemon=True).start()
+if MANAGER_AUTO_UPDATE:
+    threading.Thread(target=_auto_update_loop, daemon=True).start()
+    print(f"[*] Auto-update enabled: checking origin/{MANAGER_UPDATE_BRANCH} every {MANAGER_UPDATE_INTERVAL_HOURS}h.")
 print(f"[*] Manager initialized and ready. (Service URL: {SERVER_URL_DISPLAY})")
 
 if __name__ == '__main__':

--- a/worker_template.py
+++ b/worker_template.py
@@ -1318,38 +1318,71 @@ def has_svtav1(cmd):
     except:
         return False
 
+# Minimum supported FFmpeg = 7.1, expressed as its libavformat version (61.7).
+# The library version is the one signal every build reports identically —
+# distro strings ("7.1.5-0+deb13u1"), BtbN names ("n7.1-latest") and git
+# snapshots ("N-125708-g...") all differ, but the "libavformat 61. 7.100"
+# banner line is universal.
+_MIN_LAVF = (61, 7)
+
+def ffmpeg_meets_min_version(cmd):
+    """True when `cmd -version` reports libavformat >= 7.1's (61.7).
+    Returns True on parse failure — an unreadable banner shouldn't brick a
+    worker whose encoder support was already verified by has_svtav1()."""
+    try:
+        res = subprocess.run([cmd, "-version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                             encoding='utf-8', errors='replace', timeout=15)
+        out = res.stdout or ""
+        m = re.search(r'libavformat\s+(\d+)\.\s*(\d+)', out)
+        if not m:
+            return True
+        ver = (int(m.group(1)), int(m.group(2)))
+        if ver < _MIN_LAVF:
+            first = out.splitlines()[0] if out else cmd
+            print(f"[!] {first.strip()}")
+            print(f"[!] This FFmpeg is older than the supported minimum (7.1).")
+            return False
+        # Informational only: unreleased dev snapshots have caused real
+        # encode/mux regressions in this swarm — recommend a release build.
+        if re.search(r'^ffmpeg version [Nn]-\d+-g', out):
+            print("[!] WARNING: this FFmpeg is a git development snapshot, not a release.")
+            print("    Dev builds have caused broken uploads before — a stable release (7.1+) is recommended.")
+        return True
+    except Exception:
+        return True
+
 def check_ffmpeg():
     global FFMPEG_CMD, FFPROBE_CMD
-    
+
     local_ffmpeg = os.path.abspath("ffmpeg.exe" if platform.system() == "Windows" else "./ffmpeg")
     local_ffprobe = os.path.abspath("ffprobe.exe" if platform.system() == "Windows" else "./ffprobe")
-    
-    if os.path.exists(local_ffmpeg) and has_svtav1(local_ffmpeg):
+
+    if os.path.exists(local_ffmpeg) and has_svtav1(local_ffmpeg) and ffmpeg_meets_min_version(local_ffmpeg):
         FFMPEG_CMD = local_ffmpeg
         if os.path.exists(local_ffprobe): FFPROBE_CMD = local_ffprobe
         return
 
-    if shutil.which("ffmpeg") and has_svtav1("ffmpeg"):
+    if shutil.which("ffmpeg") and has_svtav1("ffmpeg") and ffmpeg_meets_min_version("ffmpeg"):
         FFMPEG_CMD = "ffmpeg"
         FFPROBE_CMD = "ffprobe"
         return
 
-    print("[!] Valid FFmpeg with libsvtav1 not found.")
-    
+    print("[!] No FFmpeg found with libsvtav1 support at version 7.1 or newer.")
+
     download_success = False
     if platform.system() == "Windows":
         download_success = download_ffmpeg_windows()
     else:
         download_success = download_ffmpeg_linux()
-        
+
     if download_success:
         if os.path.exists(local_ffmpeg) and has_svtav1(local_ffmpeg):
             FFMPEG_CMD = local_ffmpeg
             if os.path.exists(local_ffprobe): FFPROBE_CMD = local_ffprobe
             return
 
-    print("\n[CRITICAL ERROR] Could not find or download a version of FFmpeg with 'libsvtav1' support.")
-    print("Please install FFmpeg with SVT-AV1 support manually.")
+    print("\n[CRITICAL ERROR] Could not find or download FFmpeg 7.1+ with 'libsvtav1' support.")
+    print("Please install FFmpeg 7.1 or newer with SVT-AV1 support manually.")
     sys.exit(1)
 
 def verify_connection(manager_url):

--- a/worker_template.py
+++ b/worker_template.py
@@ -113,7 +113,7 @@ except ImportError as _e:
 DEFAULT_MANAGER_URL = "https://encode.fractumseraph.net/"
 DEFAULT_USERNAME = "Anonymous"
 DEFAULT_WORKERNAME = f"Node-{int(time.time())}"
-WORKER_VERSION = "3.4.1"
+WORKER_VERSION = "3.4.2"
 WORKER_SECRET = os.environ.get("WORKER_SECRET", "DefaultInsecureSecret")
 
 SHUTDOWN_EVENT = threading.Event()
@@ -1080,14 +1080,22 @@ def _compute_source_hash(dl_url, is_local):
 # ==============================================================================
 
 def _ffmpeg_primary_url():
-    """Return the primary upstream URL for the current platform/arch."""
+    """Return the primary upstream URL for the current platform/arch.
+
+    Pinned to BtbN's 7.1 RELEASE-branch builds, NOT master-latest: master is a
+    daily dev snapshot, and nodes running it have hit real regressions in
+    production (an mp4 muxer assertion abort mid-encode, and fragmented-mp4
+    output the manager's ffprobe reads as 0-duration — every upload rejected).
+    'n7.1-latest' still receives bugfix rebuilds of the stable branch.
+    (arm64 also moved to BtbN: the johnvansickle static builds don't include
+    libsvtav1, so auto-download could never produce a usable encoder there.)"""
     if platform.system() == "Windows":
-        return "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
+        return "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-win64-gpl-7.1.zip"
     arch = platform.machine().lower()
     if arch in ['x86_64', 'amd64']:
-        return "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
+        return "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linux64-gpl-7.1.tar.xz"
     elif arch in ['aarch64', 'arm64']:
-        return "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz"
+        return "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linuxarm64-gpl-7.1.tar.xz"
     return None
 
 def _save_ffmpeg_meta(url):
@@ -1111,6 +1119,7 @@ def update_ffmpeg_if_stale():
     last download.  A full download (~100-200 MB) only happens when the
     upstream file has actually changed.
     """
+    global FFMPEG_CMD, FFPROBE_CMD
     local_bin = os.path.abspath("ffmpeg.exe" if platform.system() == "Windows" else "./ffmpeg")
     if not os.path.exists(local_bin):
         return  # nothing local to update; check_ffmpeg() handles first install
@@ -1128,6 +1137,19 @@ def update_ffmpeg_if_stale():
             if m.get('url') == url:
                 stored_etag = m.get('etag', '')
                 stored_lm   = m.get('last_modified', '')
+            elif m.get('url'):
+                # The download channel changed (e.g. master-latest -> pinned
+                # n7.1 release): the local binary came from the WRONG channel,
+                # so replace it now instead of silently keeping it forever.
+                print("[*] FFmpeg download channel changed — fetching the pinned build...")
+                ok = download_ffmpeg_windows() if platform.system() == "Windows" else download_ffmpeg_linux()
+                if ok:
+                    _save_ffmpeg_meta(url)
+                    _lp = os.path.abspath("ffprobe.exe" if platform.system() == "Windows" else "./ffprobe")
+                    FFMPEG_CMD = local_bin
+                    if os.path.exists(_lp): FFPROBE_CMD = _lp
+                    print("[*] FFmpeg updated successfully.")
+                return
         except Exception:
             pass
 
@@ -1160,7 +1182,6 @@ def update_ffmpeg_if_stale():
     if ok:
         _save_ffmpeg_meta(url)
         # Re-point FFMPEG_CMD to the freshly extracted binary
-        global FFMPEG_CMD, FFPROBE_CMD
         local_ffprobe = os.path.abspath("ffprobe.exe" if platform.system() == "Windows" else "./ffprobe")
         FFMPEG_CMD = local_bin
         if os.path.exists(local_ffprobe):
@@ -1171,8 +1192,8 @@ def download_ffmpeg_windows():
     print("[*] FFmpeg not found. Attempting download (FULL Version ~128MB)...")
     
     urls = [
-        "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
-        "https://vsv.fractumseraph.net/ffmpeg-master-latest-win64-gpl.zip"
+        "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-win64-gpl-7.1.zip",
+        "https://vsv.fractumseraph.net/ffmpeg-n7.1-latest-win64-gpl-7.1.zip"
     ]
     
     temp_zip = "ffmpeg_temp.zip"
@@ -1229,9 +1250,10 @@ def download_ffmpeg_linux():
     arch = platform.machine().lower()
     
     if arch in ['x86_64', 'amd64']:
-        url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
+        url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linux64-gpl-7.1.tar.xz"
     elif arch in ['aarch64', 'arm64']:
-        url = "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz"
+        # BtbN, not johnvansickle: the JVS static builds have no libsvtav1.
+        url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linuxarm64-gpl-7.1.tar.xz"
     else:
         print(f"[!] Unsupported architecture for auto-download: {arch}")
         return False
@@ -1599,7 +1621,7 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
             prog_total = src_dur if src_dur > 0 else dur_sec
 
         # ---- Encode (2 attempts) ----
-        proc = None; log_buffer = []
+        proc = None; log_buffer = []; _trunc_note = None
         report_chunk("processing", 0)
         for _att in range(2):
             if SHUTDOWN_EVENT.is_set(): break
@@ -1657,7 +1679,32 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                 if proc.poll() is None:
                     try: proc.kill()
                     except Exception: pass
-            if proc.returncode == 0 or SHUTDOWN_EVENT.is_set(): break
+            if SHUTDOWN_EVENT.is_set(): break
+            if proc.returncode == 0:
+                # Self-check BEFORE uploading: a dropped source stream can make
+                # ffmpeg see a premature EOF and finish "successfully" with only
+                # part of the chunk encoded ("Stream ends prematurely" in the
+                # log, rc 0). The manager would reject it anyway (duration
+                # mismatch) — catching it here turns an upload+reject+strike
+                # into an immediate local retry. Mirrors the manager's tolerances.
+                if kind == 'video' and bool(chunk.get('is_last')) and src_dur > 0:
+                    _exp_dur = max(0.0, src_dur - start_sec)
+                else:
+                    _exp_dur = dur_sec
+                if kind == 'video':
+                    _tol = max(10.0, _exp_dur * 0.10) if chunk.get('is_last') else max(2.0, _exp_dur * 0.05)
+                else:
+                    _tol = max(10.0, _exp_dur * 0.05)
+                _odur = _probe_local_duration(out_path)
+                if _exp_dur > 0 and _odur < _exp_dur - _tol:
+                    _trunc_note = f"{_odur:.1f}s of {_exp_dur:.1f}s"
+                    log(worker_id, f"Chunk output truncated ({_trunc_note}) — source stream likely "
+                                   f"dropped mid-encode ({chunk_tag}). Retrying.", "WARN")
+                    try: os.remove(out_path)
+                    except OSError: pass
+                    continue  # burn this attempt, re-encode
+                _trunc_note = None
+                break
 
         def upload_chunk_log():
             try:
@@ -1686,7 +1733,10 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
 
         if proc is None or proc.returncode != 0 or not os.path.exists(out_path):
             rc = proc.returncode if proc else -1
-            err_msg = f"FFmpeg exited with code {rc} ({chunk_tag})"
+            if _trunc_note:
+                err_msg = f"Truncated output ({_trunc_note}) — source stream interrupted ({chunk_tag})"
+            else:
+                err_msg = f"FFmpeg exited with code {rc} ({chunk_tag})"
             log(worker_id, err_msg, "ERROR")
             report_chunk("failed", error_msg=err_msg)
             report_error(job_id, "chunk_encode_failure", err_msg,
@@ -2439,7 +2489,7 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                     "created_at":       time.time(),
                 })
 
-                proc = None; enc_time = 0
+                proc = None; enc_time = 0; _wf_trunc_note = None
                 log_buffer = []  # defined before the loop: a pre-first-attempt
                                  # shutdown must not NameError the failure dump
                 for _enc_attempt in range(3):
@@ -2527,8 +2577,26 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                             except Exception: pass
 
                     enc_time = time.time() - start_enc
-                    if proc.returncode == 0 or SHUTDOWN_EVENT.is_set(): break
-                
+                    if SHUTDOWN_EVENT.is_set(): break
+                    if proc.returncode == 0:
+                        # Self-check BEFORE uploading: a dropped source stream
+                        # can make ffmpeg see a premature EOF and exit 0 with a
+                        # truncated file. The manager rejects those anyway —
+                        # catching it locally saves the (large) upload and
+                        # retries immediately. Same tolerance as the manager.
+                        if total_sec > 0:
+                            _wf_odur = _probe_local_duration(local_dst)
+                            _wf_tol = max(10.0, total_sec * 0.05)
+                            if _wf_odur < total_sec - _wf_tol:
+                                _wf_trunc_note = f"{_wf_odur:.1f}s of {total_sec:.1f}s"
+                                log(worker_id, f"Encode output truncated ({_wf_trunc_note}) — source "
+                                               "stream likely dropped mid-encode. Retrying.", "WARN")
+                                try: os.remove(local_dst)
+                                except OSError: pass
+                                continue  # burn this attempt, re-encode
+                        _wf_trunc_note = None
+                        break
+
                 gz_log_path = os.path.join(temp_dir, "encode.log.gz")
                 try:
                     with open(raw_log_path, 'rb') as f_in, gzip.open(gz_log_path, 'wb') as f_out:
@@ -2651,6 +2719,8 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                 else:
                     rc = proc.returncode if proc else -1
                     err_msg = f"FFmpeg exited with code {rc}"
+                    if _wf_trunc_note:
+                        err_msg = f"Truncated output ({_wf_trunc_note}) — source stream interrupted"
                     if SHUTDOWN_EVENT.is_set(): err_msg = "Aborted by user/update"
 
                     log(worker_id, err_msg, "ERROR")


### PR DESCRIPTION
Four related changes on one branch — the first two driven by live-server log analysis, the second two requested follow-ups.

## 1. Workers ran daily FFmpeg *dev snapshots* — pin to the 7.1 release branch

Worker auto-download used BtbN `ffmpeg-master-latest` (daily dev snapshot) and the updater kept nodes on every new one. A volunteer node on FFmpeg 8-dev hit two production regressions: an mp4 muxer assertion abort mid-encode, and fragmented-mp4 chunks the manager's ffprobe reads as **0.0s** — every upload rejected, all its work wasted.

- All download URLs pinned to **`ffmpeg-n7.1-latest-*-gpl`** release builds (asset names verified against the BtbN release page); still receives stable-branch bugfix rebuilds.
- The staleness updater detects a **channel change** and replaces a wrong-channel binary instead of keeping it forever.
- arm64 moved from johnvansickle (no libsvtav1 in those builds) to BtbN `linuxarm64`.

## 2. Truncated "successful" encodes — self-check before upload

Encode logs show `Stream ends prematurely … Will reconnect` on long encodes; a reconnect landing on a dead stream makes ffmpeg exit 0 with a partial file. The manager rejected all of these correctly, but hours of encode time and a large upload were wasted each time. Workers (**3.4.2**) now ffprobe their own output before uploading — same tolerances as the manager — and burn a local retry instead.

## 3. FFmpeg 7.1+ required at worker startup

`check_ffmpeg` now requires libsvtav1 **and** FFmpeg ≥ 7.1, verified via the `libavformat` banner version (61.7) — the one line all build styles (distro, BtbN, git snapshot) report identically. Too-old system installs are rejected with a clear message and the pinned 7.1 build is downloaded instead. Git dev snapshots pass the age gate but print a warning. Tested against 7 banner styles (6.1/7.0 rejected; 7.1/7.1.5/n7.1/8.0 pass; dev warns; unparseable passes open) plus a real 6.1 binary.

## 4. Manager self-update from GitHub

`MANAGER_AUTO_UPDATE = True` in `config.py`: every `MANAGER_UPDATE_INTERVAL_HOURS` (default 6) the manager fetches `origin/MANAGER_UPDATE_BRANCH`, fast-forwards, refreshes `requirements.txt`, syncs + backs up the DB, and restarts into the new code:

1. `MANAGER_RESTART_CMD` if configured (e.g. `systemctl --user restart …`),
2. else a **zero-downtime gunicorn reload** (SIGHUP to the master),
3. else a clean exit under systemd (`Restart=always` relaunches) — gated on the parent process actually being systemd, so a hand-launched `python manager.py` is never killed.

Safety: repos with local *tracked* modifications are skipped (untracked `config.py` doesn't block); only fast-forward pulls; diverged history is reported, never force-reset. Verified with a scratch origin (fetch/compare/dirty-skip/untracked-ok/ff-pull all exercised) and a live manager boot.

Off by default for existing configs — add `MANAGER_AUTO_UPDATE = True` to `config.py` to enable. Security note in the config example: whoever can push to the branch controls the server.

## Deployment notes

- Upload `ffmpeg-n7.1-latest-win64-gpl-7.1.zip` to the `vsv.fractumseraph.net` mirror (fallback URL changed).
- To enable auto-update on the running server, add the `MANAGER_AUTO_UPDATE` block from `config.py.example` to `config.py` — after this one last manual `git pull` + restart, future updates apply themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)