### PR TITLE
Payout API + admin panel: settle the FractumCoin earnings ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,16 @@ Workers can attach a FractumCoin wallet address with `--wallet ADDR` (or `&walle
 - Ledger rows are never rewritten by retries, archives, or chunk cleanup, and re-uploads to an already-completed job earn nothing — the payout record is stable.
 - The public scoreboard is a view of the same ledger, so score = minutes of successful encodes uploaded, identical between chunked and whole-file work. Existing history is backfilled into the ledger on first startup (with no wallet attached).
 
-**Payouts:** `GET /api/earnings` (admin auth) returns per-wallet totals (`total_minutes`, `unpaid_minutes`, upload counts, first/last activity) plus recent ledger rows. Work uploaded without a wallet appears under `(no wallet)`. A `paid` flag exists on every row for future payout tooling.
+**Payouts:** `GET /api/earnings` (admin auth) returns per-wallet totals (`total_minutes`, `unpaid_minutes`, upload counts, first/last activity) plus recent ledger rows. Work uploaded without a wallet appears under `(no wallet)` and cannot be paid.
+
+Actual coin settlement is done by the **payout daemon** (FractumCoin repo, `encode-rewards/`), which runs next to the coin wallet — the manager never talks to the coin daemon, so wallet RPC stays localhost-only on that machine. The flow:
+
+1. The daemon polls `GET /api/payouts/pending` (authenticated with `PAYOUT_TOKEN` via the `X-Payout-Token` header) for unpaid ledger rows grouped by wallet.
+2. It validates each address, converts minutes → FRCT at its configured rate, sends coins, then settles the rows via `POST /api/payouts/mark_paid` (idempotent — retries after a lost response can't double-record; rows already paid update nothing).
+3. **Hybrid approval:** wallets owed at most the auto cap are paid automatically. Larger balances need an admin click in the **FRACTUM_PAYOUTS** panel on `/admin` (`POST /api/payouts/approve`). Approval is a snapshot of the wallet's unpaid rows at click time — work uploaded afterwards accumulates unapproved.
+4. The daemon reports heartbeat + invalid addresses via `POST /api/payouts/report`; the admin panel shows daemon health (dry-run/paused state, treasury balance, rate), per-wallet owed FRCT with AUTO / NEEDS APPROVAL / INVALID ADDRESS badges, and paid history with txids.
+
+Config: `PAYOUT_TOKEN` (shared secret for the daemon; `None` disables the token path), plus `PAYOUT_RATE_FRCT_PER_MIN` / `PAYOUT_AUTO_CAP_FRCT` — **display hints for the admin UI only**; the daemon's own config is authoritative for money movement, and the UI warns when they drift apart.
 
 ---
 

--- a/config.py.example
+++ b/config.py.example
@@ -28,6 +28,22 @@ SECRET_KEY = "ChangeThisToAnotherRandomString"
 REQUIRE_WORKER_TOKEN = True
 
 # ==============================================================================
+# FRACTUMCOIN PAYOUTS
+# ==============================================================================
+# Shared secret for the payout daemon (FractumCoin repo, encode-rewards/) that
+# runs next to the coin wallet and settles the earnings ledger. It presents
+# this as an X-Payout-Token header. None disables the token path entirely
+# (admin Basic auth still reaches the payout API for testing).
+PAYOUT_TOKEN = None
+
+# Display hints for the admin UI ONLY — the payout daemon's own config is
+# authoritative for real money movement. Keep them in sync so the UI's
+# "FRCT owed" figures and AUTO/NEEDS-APPROVAL badges match what the daemon
+# actually does (the UI warns when the daemon reports different values).
+PAYOUT_RATE_FRCT_PER_MIN = 1.0
+PAYOUT_AUTO_CAP_FRCT = 250.0
+
+# ==============================================================================
 # DATABASE BACKUPS
 # ==============================================================================
 # The database is the single source of truth for the whole queue and the

--- a/manager.py
+++ b/manager.py
@@ -510,6 +510,15 @@ def sanitize_wallet(val):
     cleaned = re.sub(r'[^a-zA-Z0-9:_.-]', '', str(val))[:128]
     return cleaned or None
 
+def sanitize_txid(val):
+    """Normalize a payout transaction id for storage. Kept wider than
+    sanitize_input because the daemon may send a COMMA-JOINED list of txids
+    (one per wallet in per-address sendtoaddress mode) — stripping the commas
+    would fuse them into one unusable, unverifiable string."""
+    if not val: return None
+    cleaned = re.sub(r'[^a-zA-Z0-9,:_.-]', '', str(val))[:2048]
+    return cleaned or None
+
 def _record_earning(conn, wallet, worker_id, job_id, kind, chunk_index, minutes):
     """Append one verified upload to the FractumCoin earnings ledger.
     Caller holds db_lock and commits."""
@@ -606,11 +615,17 @@ def requires_payout_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         token = request.headers.get('X-Payout-Token')
-        if token and PAYOUT_TOKEN and secrets.compare_digest(str(token), str(PAYOUT_TOKEN)):
+        # Header values are latin-1 in WSGI; compare as bytes so a stray high
+        # byte yields a clean 401 rather than a TypeError 500 from compare_digest.
+        if token and PAYOUT_TOKEN and secrets.compare_digest(
+                str(token).encode('utf-8', 'ignore'), str(PAYOUT_TOKEN).encode('utf-8', 'ignore')):
             return f(*args, **kwargs)
         auth = request.authorization
         if auth and check_auth(auth.username, auth.password):
             return f(*args, **kwargs)
+        # Failed auth on the money API is worth a log line — token brute-force
+        # against payouts would otherwise be invisible.
+        log_event("WARN", f"Payout API auth failure from {get_remote_address()}")
         return jsonify({"status": "error", "message": "Unauthorized"}), 401
     return decorated
 
@@ -2945,6 +2960,8 @@ def api_earnings():
 
 PAYOUT_IDS_PER_WALLET = 5000   # oldest-first cap per run; remainder next cycle
 SQLITE_IN_CHUNK = 500          # stay well under SQLite's parameter limit
+PAYOUT_MAX_ENTRIES = 1000      # reject oversized mark_paid batches before the
+PAYOUT_MAX_IDS = 100000        # global write lock (authenticated-DoS guard)
 
 @app.route('/api/payouts/pending')
 @requires_payout_auth
@@ -2959,8 +2976,7 @@ def api_payouts_pending():
             c = conn.cursor()
             c.execute("""
                 SELECT wallet,
-                       ROUND(SUM(minutes), 3) as unpaid_minutes,
-                       ROUND(SUM(CASE WHEN approved=1 THEN minutes ELSE 0 END), 3) as approved_minutes,
+                       ROUND(SUM(minutes), 3) as total_unpaid_minutes,
                        MIN(timestamp) as first_upload
                 FROM earnings
                 WHERE paid=0 AND wallet IS NOT NULL AND wallet != ''
@@ -2968,16 +2984,29 @@ def api_payouts_pending():
             groups = [dict(r) for r in c.fetchall()]
             wallets = []
             for g in groups:
-                c.execute("SELECT id, approved FROM earnings "
+                # Sum minutes over EXACTLY the rows we hand out — never the
+                # full-wallet aggregate. If a wallet has more than the cap of
+                # unpaid rows, the daemon pays only what it can settle this
+                # run (`served_minutes`/ids stay in lockstep) and the rest
+                # comes next cycle. Paying the uncapped total against a capped
+                # id set silently overpays the remainder every cycle.
+                c.execute("SELECT id, approved, minutes FROM earnings "
                           "WHERE paid=0 AND wallet=? ORDER BY id ASC LIMIT ?",
                           (g['wallet'], PAYOUT_IDS_PER_WALLET))
                 rows = c.fetchall()
+                served_minutes = round(sum(r['minutes'] or 0 for r in rows), 3)
+                served_approved_minutes = round(
+                    sum(r['minutes'] or 0 for r in rows if r['approved']), 3)
                 c.execute("SELECT status FROM payout_wallet_status WHERE wallet=?", (g['wallet'],))
                 srow = c.fetchone()
                 wallets.append({
                     "wallet": g['wallet'],
-                    "unpaid_minutes": g['unpaid_minutes'],
-                    "approved_minutes": g['approved_minutes'],
+                    # served_* are authoritative for payment; total_* is for
+                    # UI/context only. truncated flags the cap being hit.
+                    "served_minutes": served_minutes,
+                    "served_approved_minutes": served_approved_minutes,
+                    "total_unpaid_minutes": g['total_unpaid_minutes'],
+                    "truncated": len(rows) >= PAYOUT_IDS_PER_WALLET,
                     "first_upload": g['first_upload'],
                     "earning_ids": [r['id'] for r in rows],
                     "approved_earning_ids": [r['id'] for r in rows if r['approved']],
@@ -2998,7 +3027,7 @@ def api_payouts_mark_paid():
     Idempotent: rows already paid update nothing, and a pure retry (updated=0)
     writes no history row, so daemon retries after a lost response converge."""
     data = request.json or {}
-    txid = sanitize_input(data.get('txid')) or None
+    txid = sanitize_txid(data.get('txid'))
     try:
         rate = float(data.get('rate_frct_per_min') or 0)
     except (TypeError, ValueError):
@@ -3006,21 +3035,45 @@ def api_payouts_mark_paid():
     entries = data.get('payouts')
     if not isinstance(entries, list) or not entries:
         return jsonify({"status": "error", "message": "payouts list required"}), 400
+    if len(entries) > PAYOUT_MAX_ENTRIES:
+        return jsonify({"status": "error", "message": "too many payout entries"}), 400
+
+    # Validate and normalize EVERY entry before taking db_lock. A 400 raised
+    # mid-transaction would roll back rows for entries the daemon already
+    # broadcast, and it would re-send them next cycle (double-spend). All-or-
+    # nothing: reject the whole batch up front or settle it atomically.
+    clean = []
+    total_ids = 0
+    for entry in entries:
+        wallet = sanitize_wallet((entry or {}).get('wallet'))
+        ids = (entry or {}).get('earning_ids')
+        if not wallet or not isinstance(ids, list) or not ids:
+            return jsonify({"status": "error", "message": "each payout needs wallet and earning_ids"}), 400
+        norm_ids = []
+        for i in ids:
+            # bool is an int subclass — reject it explicitly, and reject floats
+            # so a daemon bug can't settle the wrong rows via silent int().
+            if isinstance(i, bool) or not isinstance(i, int):
+                return jsonify({"status": "error", "message": "earning_ids must be integers"}), 400
+            norm_ids.append(i)
+        total_ids += len(norm_ids)
+        if total_ids > PAYOUT_MAX_IDS:
+            return jsonify({"status": "error", "message": "too many earning_ids in batch"}), 400
+        try:
+            minutes = round(float(entry.get('minutes') or 0), 3)
+            frct = round(float(entry.get('frct') or 0), 8)
+        except (TypeError, ValueError):
+            minutes, frct = 0, 0
+        clean.append({"wallet": wallet, "ids": norm_ids, "minutes": minutes,
+                      "frct": frct, "mode": sanitize_input(entry.get('mode')) or 'auto'})
 
     results = []
     now = datetime.now()
     with db_lock:
         conn = db_handler.get_connection(); c = conn.cursor()
         try:
-            for entry in entries:
-                wallet = sanitize_wallet((entry or {}).get('wallet'))
-                ids = (entry or {}).get('earning_ids')
-                if not wallet or not isinstance(ids, list) or not ids:
-                    return jsonify({"status": "error", "message": "each payout needs wallet and earning_ids"}), 400
-                try:
-                    ids = [int(i) for i in ids]
-                except (TypeError, ValueError):
-                    return jsonify({"status": "error", "message": "earning_ids must be integers"}), 400
+            for entry in clean:
+                wallet, ids = entry["wallet"], entry["ids"]
                 updated = 0
                 for i in range(0, len(ids), SQLITE_IN_CHUNK):
                     chunk = ids[i:i + SQLITE_IN_CHUNK]
@@ -3035,17 +3088,17 @@ def api_payouts_mark_paid():
                     # No duplicate history when the daemon re-pushes a
                     # settlement this DB lost (RAM-mode flush window) — the
                     # same wallet+txid pair is the same real-world payment.
-                    c.execute("SELECT 1 FROM payouts WHERE wallet=? AND txid IS ? LIMIT 1", (wallet, txid))
-                    if c.fetchone() is None:
-                        try:
-                            minutes = round(float(entry.get('minutes') or 0), 3)
-                            frct = round(float(entry.get('frct') or 0), 8)
-                        except (TypeError, ValueError):
-                            minutes, frct = 0, 0
-                        mode = sanitize_input(entry.get('mode')) or 'auto'
+                    # Only dedupe on a real txid: a NULL txid ("wallet + NULL")
+                    # would match ANY prior no-txid payout for that wallet and
+                    # silently drop every later history row.
+                    dup = None
+                    if txid is not None:
+                        c.execute("SELECT 1 FROM payouts WHERE wallet=? AND txid=? LIMIT 1", (wallet, txid))
+                        dup = c.fetchone()
+                    if dup is None:
                         c.execute("INSERT INTO payouts (created_at, wallet, minutes, frct, rate, txid, earning_count, mode) "
                                   "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                                  (now, wallet, minutes, frct, rate, txid, updated, mode))
+                                  (now, wallet, entry["minutes"], entry["frct"], rate, txid, updated, entry["mode"]))
                 results.append({"wallet": wallet, "updated": updated,
                                 "already_paid": len(ids) - updated})
             conn.commit()
@@ -3095,13 +3148,19 @@ def api_payouts_report():
     dry-run state, treasury balance, and invalid addresses show in the UI."""
     data = request.json or {}
     heartbeat = data.get('heartbeat')
-    statuses = data.get('wallet_status') or []
+    statuses = data.get('wallet_status')
+    if not isinstance(statuses, list):
+        statuses = []
+    statuses = statuses[:PAYOUT_MAX_ENTRIES]   # bound the write under db_lock
     now = datetime.now()
     with db_lock:
         conn = db_handler.get_connection(); c = conn.cursor()
         try:
             if isinstance(heartbeat, dict):
-                heartbeat['received_at'] = now.isoformat()
+                # astimezone() stamps the server's UTC offset so the admin
+                # browser computes heartbeat age correctly regardless of its
+                # own timezone (a tz-less string is parsed as browser-local).
+                heartbeat['received_at'] = now.astimezone().isoformat()
                 c.execute("INSERT OR REPLACE INTO payout_meta (key, value) VALUES ('daemon_heartbeat', ?)",
                           (json.dumps(heartbeat),))
             for s in statuses:

--- a/manager.py
+++ b/manager.py
@@ -96,6 +96,23 @@ try:
     except ImportError:
         REQUIRE_WORKER_TOKEN = True
 
+    # FractumCoin payouts: shared secret for the payout daemon (X-Payout-Token
+    # header). None disables the payout API for the daemon entirely — admin
+    # Basic auth still works for testing. Rate/cap are ADMIN UI DISPLAY HINTS
+    # only; the daemon's own config is authoritative for money movement.
+    try:
+        from config import PAYOUT_TOKEN
+    except ImportError:
+        PAYOUT_TOKEN = None
+    try:
+        from config import PAYOUT_RATE_FRCT_PER_MIN
+    except ImportError:
+        PAYOUT_RATE_FRCT_PER_MIN = 1.0
+    try:
+        from config import PAYOUT_AUTO_CAP_FRCT
+    except ImportError:
+        PAYOUT_AUTO_CAP_FRCT = 250.0
+
     # Periodic timestamped backups of the job/earnings database, so a
     # corruption or bad disk write doesn't wipe the whole queue.
     try:
@@ -534,7 +551,8 @@ def add_security_headers(response):
 
 @app.before_request
 def csrf_protect():
-    if request.method == "POST" and request.path.startswith('/api/admin_action'):
+    if request.method == "POST" and request.path.startswith(
+            ('/api/admin_action', '/api/payouts/approve', '/api/payouts/unapprove')):
         origin = request.headers.get('Origin')
         referer = request.headers.get('Referer')
         target = origin or referer or ""
@@ -579,6 +597,21 @@ def requires_worker_auth(f):
         if not secrets.compare_digest(str(token), str(WORKER_SECRET)):
             return jsonify({"status": "error", "message": "Unauthorized Worker"}), 401
         return f(*args, **kwargs)
+    return decorated
+
+def requires_payout_auth(f):
+    """Auth for the FractumCoin payout daemon on the Pi. Accepts either the
+    dedicated X-Payout-Token (revocable, scoped — the admin password never
+    lives on the Pi) or admin Basic auth as a testing fallback."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = request.headers.get('X-Payout-Token')
+        if token and PAYOUT_TOKEN and secrets.compare_digest(str(token), str(PAYOUT_TOKEN)):
+            return f(*args, **kwargs)
+        auth = request.authorization
+        if auth and check_auth(auth.username, auth.password):
+            return f(*args, **kwargs)
+        return jsonify({"status": "error", "message": "Unauthorized"}), 401
     return decorated
 
 def verify_upload(filepath):
@@ -1743,6 +1776,54 @@ def init_db():
             if backfilled_full > 0 or backfilled_chunks > 0:
                 print(f"[*] Earnings ledger backfilled from history: {backfilled_full} whole file(s), {backfilled_chunks} chunk(s).")
 
+        # Payout tooling (additive, idempotent): `approved` marks unpaid rows an
+        # admin has cleared for an over-cap payout; `paid_txid`/`paid_at` record
+        # the FractumCoin transaction that settled the row.
+        try: cursor.execute("ALTER TABLE earnings ADD COLUMN approved INTEGER DEFAULT 0")
+        except sqlite3.OperationalError: pass
+        try: cursor.execute("ALTER TABLE earnings ADD COLUMN paid_txid TEXT")
+        except sqlite3.OperationalError: pass
+        try: cursor.execute("ALTER TABLE earnings ADD COLUMN paid_at TIMESTAMP")
+        except sqlite3.OperationalError: pass
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_earnings_unpaid ON earnings(paid, wallet)")
+
+        # Payout history: one row per wallet per settled batch, written by
+        # /api/payouts/mark_paid. `txid` is shared across wallets when the
+        # daemon batches a run into a single sendmany transaction.
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS payouts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TIMESTAMP,
+                wallet TEXT NOT NULL,
+                minutes REAL,
+                frct REAL,
+                rate REAL,
+                txid TEXT,
+                earning_count INTEGER,
+                mode TEXT
+            )
+        ''')
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_payouts_wallet ON payouts(wallet)")
+
+        # Daemon-reported wallet problems (e.g. failed validateaddress) so bad
+        # addresses surface in the admin UI instead of silently never paying.
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS payout_wallet_status (
+                wallet TEXT PRIMARY KEY,
+                status TEXT,
+                detail TEXT,
+                updated_at TIMESTAMP
+            )
+        ''')
+
+        # Daemon heartbeat and other payout key/values.
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS payout_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            )
+        ''')
+
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS error_reports (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2853,6 +2934,214 @@ def api_earnings():
         finally:
             conn.close()
     return jsonify({"wallets": wallets, "recent": recent})
+
+# ==============================================================================
+# FRACTUMCOIN PAYOUTS
+# ==============================================================================
+# The payout daemon on the Pi (FractumCoin repo, encode-rewards/) polls
+# /api/payouts/pending, sends FRCT over localhost RPC, then settles rows via
+# /api/payouts/mark_paid. The manager never talks to the coin daemon itself —
+# wallet RPC stays localhost-only on the Pi.
+
+PAYOUT_IDS_PER_WALLET = 5000   # oldest-first cap per run; remainder next cycle
+SQLITE_IN_CHUNK = 500          # stay well under SQLite's parameter limit
+
+@app.route('/api/payouts/pending')
+@requires_payout_auth
+def api_payouts_pending():
+    """Work order for the payout daemon: unpaid ledger rows grouped by wallet.
+    Rows without a wallet (historical backfill, workers without --wallet) are
+    excluded here — '(no wallet)' in /api/earnings is a display artifact and
+    must never reach validateaddress or sendmany."""
+    with read_lock():
+        conn = db_handler.get_connection(); conn.row_factory = sqlite3.Row
+        try:
+            c = conn.cursor()
+            c.execute("""
+                SELECT wallet,
+                       ROUND(SUM(minutes), 3) as unpaid_minutes,
+                       ROUND(SUM(CASE WHEN approved=1 THEN minutes ELSE 0 END), 3) as approved_minutes,
+                       MIN(timestamp) as first_upload
+                FROM earnings
+                WHERE paid=0 AND wallet IS NOT NULL AND wallet != ''
+                GROUP BY wallet ORDER BY first_upload ASC""")
+            groups = [dict(r) for r in c.fetchall()]
+            wallets = []
+            for g in groups:
+                c.execute("SELECT id, approved FROM earnings "
+                          "WHERE paid=0 AND wallet=? ORDER BY id ASC LIMIT ?",
+                          (g['wallet'], PAYOUT_IDS_PER_WALLET))
+                rows = c.fetchall()
+                c.execute("SELECT status FROM payout_wallet_status WHERE wallet=?", (g['wallet'],))
+                srow = c.fetchone()
+                wallets.append({
+                    "wallet": g['wallet'],
+                    "unpaid_minutes": g['unpaid_minutes'],
+                    "approved_minutes": g['approved_minutes'],
+                    "first_upload": g['first_upload'],
+                    "earning_ids": [r['id'] for r in rows],
+                    "approved_earning_ids": [r['id'] for r in rows if r['approved']],
+                    "status": srow['status'] if srow else 'ok',
+                })
+        finally:
+            conn.close()
+    return jsonify({
+        "rate_hint_frct_per_min": PAYOUT_RATE_FRCT_PER_MIN,
+        "auto_cap_hint_frct": PAYOUT_AUTO_CAP_FRCT,
+        "wallets": wallets,
+    })
+
+@app.route('/api/payouts/mark_paid', methods=['POST'])
+@requires_payout_auth
+def api_payouts_mark_paid():
+    """Settle ledger rows after the daemon has broadcast a transaction.
+    Idempotent: rows already paid update nothing, and a pure retry (updated=0)
+    writes no history row, so daemon retries after a lost response converge."""
+    data = request.json or {}
+    txid = sanitize_input(data.get('txid')) or None
+    try:
+        rate = float(data.get('rate_frct_per_min') or 0)
+    except (TypeError, ValueError):
+        rate = 0
+    entries = data.get('payouts')
+    if not isinstance(entries, list) or not entries:
+        return jsonify({"status": "error", "message": "payouts list required"}), 400
+
+    results = []
+    now = datetime.now()
+    with db_lock:
+        conn = db_handler.get_connection(); c = conn.cursor()
+        try:
+            for entry in entries:
+                wallet = sanitize_wallet((entry or {}).get('wallet'))
+                ids = (entry or {}).get('earning_ids')
+                if not wallet or not isinstance(ids, list) or not ids:
+                    return jsonify({"status": "error", "message": "each payout needs wallet and earning_ids"}), 400
+                try:
+                    ids = [int(i) for i in ids]
+                except (TypeError, ValueError):
+                    return jsonify({"status": "error", "message": "earning_ids must be integers"}), 400
+                updated = 0
+                for i in range(0, len(ids), SQLITE_IN_CHUNK):
+                    chunk = ids[i:i + SQLITE_IN_CHUNK]
+                    ph = ",".join("?" * len(chunk))
+                    # wallet=? guard: a confused daemon can only settle rows
+                    # belonging to the wallet it actually paid.
+                    c.execute(f"UPDATE earnings SET paid=1, paid_txid=?, paid_at=? "
+                              f"WHERE id IN ({ph}) AND paid=0 AND wallet=?",
+                              [txid, now] + chunk + [wallet])
+                    updated += c.rowcount
+                if updated > 0:
+                    # No duplicate history when the daemon re-pushes a
+                    # settlement this DB lost (RAM-mode flush window) — the
+                    # same wallet+txid pair is the same real-world payment.
+                    c.execute("SELECT 1 FROM payouts WHERE wallet=? AND txid IS ? LIMIT 1", (wallet, txid))
+                    if c.fetchone() is None:
+                        try:
+                            minutes = round(float(entry.get('minutes') or 0), 3)
+                            frct = round(float(entry.get('frct') or 0), 8)
+                        except (TypeError, ValueError):
+                            minutes, frct = 0, 0
+                        mode = sanitize_input(entry.get('mode')) or 'auto'
+                        c.execute("INSERT INTO payouts (created_at, wallet, minutes, frct, rate, txid, earning_count, mode) "
+                                  "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                                  (now, wallet, minutes, frct, rate, txid, updated, mode))
+                results.append({"wallet": wallet, "updated": updated,
+                                "already_paid": len(ids) - updated})
+            conn.commit()
+        finally:
+            conn.close()
+
+    # Paid flags are money-critical: flush the RAM DB immediately so a crash
+    # can't revert a settlement the daemon has already journaled.
+    db_handler.sync_to_disk()
+    for r in results:
+        if r["updated"] > 0:
+            log_event("INFO", f"Payout recorded: wallet {r['wallet']} settled {r['updated']} earning row(s), txid {str(txid)[:16]}")
+    return jsonify({"status": "ok", "results": results})
+
+@app.route('/api/payouts/approve', methods=['POST'])
+@app.route('/api/payouts/unapprove', methods=['POST'])
+@requires_auth
+def api_payouts_approve():
+    """Admin approval for over-cap wallets (hybrid payouts). Approval is a
+    snapshot of the wallet's CURRENT unpaid rows — work uploaded after the
+    click accumulates unapproved, so there is no open-ended standing approval.
+    Covered by the csrf_protect origin check (Basic-auth browsers auto-send
+    credentials)."""
+    data = request.json or {}
+    wallet = sanitize_wallet(data.get('wallet'))
+    if not wallet:
+        return jsonify({"status": "error", "message": "wallet required"}), 400
+    approving = request.path.endswith('/approve')
+    with db_lock:
+        conn = db_handler.get_connection(); c = conn.cursor()
+        try:
+            c.execute("UPDATE earnings SET approved=? WHERE wallet=? AND paid=0",
+                      (1 if approving else 0, wallet))
+            count = c.rowcount
+            c.execute("SELECT ROUND(SUM(minutes), 3) FROM earnings WHERE wallet=? AND paid=0 AND approved=1", (wallet,))
+            approved_minutes = c.fetchone()[0] or 0
+            conn.commit()
+        finally:
+            conn.close()
+    log_event("WARN", f"Admin {'approved' if approving else 'revoked approval for'} payout of wallet {wallet} ({count} row(s))")
+    return jsonify({"status": "ok", "rows": count, "approved_minutes": approved_minutes})
+
+@app.route('/api/payouts/report', methods=['POST'])
+@requires_payout_auth
+def api_payouts_report():
+    """Daemon telemetry: heartbeat JSON plus per-wallet address problems, so
+    dry-run state, treasury balance, and invalid addresses show in the UI."""
+    data = request.json or {}
+    heartbeat = data.get('heartbeat')
+    statuses = data.get('wallet_status') or []
+    now = datetime.now()
+    with db_lock:
+        conn = db_handler.get_connection(); c = conn.cursor()
+        try:
+            if isinstance(heartbeat, dict):
+                heartbeat['received_at'] = now.isoformat()
+                c.execute("INSERT OR REPLACE INTO payout_meta (key, value) VALUES ('daemon_heartbeat', ?)",
+                          (json.dumps(heartbeat),))
+            for s in statuses:
+                wallet = sanitize_wallet((s or {}).get('wallet'))
+                if not wallet:
+                    continue
+                status = sanitize_input(s.get('status')) or 'ok'
+                detail = str(s.get('detail') or '')[:300]
+                c.execute("INSERT OR REPLACE INTO payout_wallet_status (wallet, status, detail, updated_at) "
+                          "VALUES (?, ?, ?, ?)", (wallet, status, detail, now))
+            conn.commit()
+        finally:
+            conn.close()
+    return jsonify({"status": "ok"})
+
+@app.route('/api/payouts/status')
+@requires_auth
+def api_payouts_status():
+    """Feeds the admin UI payouts panel."""
+    with read_lock():
+        conn = db_handler.get_connection(); conn.row_factory = sqlite3.Row
+        try:
+            c = conn.cursor()
+            c.execute("SELECT * FROM payouts ORDER BY id DESC LIMIT 100")
+            history = [dict(r) for r in c.fetchall()]
+            c.execute("SELECT * FROM payout_wallet_status ORDER BY updated_at DESC")
+            wallet_status = [dict(r) for r in c.fetchall()]
+            c.execute("SELECT value FROM payout_meta WHERE key='daemon_heartbeat'")
+            row = c.fetchone()
+        finally:
+            conn.close()
+    daemon = None
+    if row:
+        try:
+            daemon = json.loads(row['value'])
+        except (ValueError, TypeError):
+            daemon = None
+    return jsonify({"history": history, "wallet_status": wallet_status, "daemon": daemon,
+                    "rate_hint_frct_per_min": PAYOUT_RATE_FRCT_PER_MIN,
+                    "auto_cap_hint_frct": PAYOUT_AUTO_CAP_FRCT})
 
 @app.route('/api/logs')
 @requires_auth

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -253,6 +253,10 @@
                     fetch('/api/payouts/status'),
                     fetch('/api/earnings?limit=1')
                 ]);
+                // fetch() does not reject on 4xx/5xx and the error bodies are
+                // valid JSON, so without this a broken/unauthorized payout API
+                // would render as a healthy "nothing owed" panel.
+                if (!pR.ok || !sR.ok || !eR.ok) throw new Error('payout API error');
                 payoutPending = await pR.json();
                 payoutStatus = await sR.json();
                 const earn = await eR.json();
@@ -268,6 +272,10 @@
             if (!strip || !tbody || !hist) return;
             if (!payoutPending || !payoutStatus) {
                 strip.textContent = '// PAYOUT API UNAVAILABLE //';
+                // Don't leave a stale owed table with live APPROVE buttons
+                // sitting under an "unavailable" header.
+                tbody.innerHTML = '<tr><td colspan="5" style="text-align:center; color:#555;">// UNAVAILABLE //</td></tr>';
+                hist.innerHTML = '<tr><td colspan="5" style="text-align:center; color:#555;">// UNAVAILABLE //</td></tr>';
                 return;
             }
 
@@ -283,14 +291,19 @@
                 strip.innerHTML = '<span style="color:var(--neon-orange)">DAEMON: NEVER REPORTED</span>';
             } else {
                 const ageMin = d.received_at ? Math.round((Date.now() - new Date(d.received_at).getTime()) / 60000) : null;
-                const stale = ageMin == null || ageMin > 30;
+                // NaN (unparseable date) and null both count as stale — a
+                // non-finite age must never render green.
+                const stale = !Number.isFinite(ageMin) || ageMin > 30;
                 let parts = [];
-                parts.push(`<span style="color:${stale ? 'var(--neon-red)' : 'var(--neon-green)'}">HEARTBEAT ${ageMin == null ? '?' : ageMin + 'm ago'}</span>`);
+                parts.push(`<span style="color:${stale ? 'var(--neon-red)' : 'var(--neon-green)'}">HEARTBEAT ${Number.isFinite(ageMin) ? ageMin + 'm ago' : '?'}</span>`);
                 if (d.dry_run) parts.push('<span style="color:var(--neon-orange)">[DRY RUN]</span>');
                 if (d.paused) parts.push('<span style="color:var(--neon-red)">[PAUSED]</span>');
-                if (d.treasury_frct != null) parts.push(`TREASURY ${d.treasury_frct} FRCT`);
-                parts.push(`RATE ${rate} FRCT/min`);
-                parts.push(`AUTO CAP ${cap} FRCT`);
+                // Escape daemon-reported values — a compromised Pi POSTing to
+                // /api/payouts/report must not inject HTML into the admin page
+                // (these run with the admin's cached credentials).
+                if (d.treasury_frct != null) parts.push(`TREASURY ${escapeHTML(String(d.treasury_frct))} FRCT`);
+                parts.push(`RATE ${escapeHTML(String(rate))} FRCT/min`);
+                parts.push(`AUTO CAP ${escapeHTML(String(cap))} FRCT`);
                 if (d.rate_frct_per_min != null && rateHint != null && d.rate_frct_per_min !== rateHint)
                     parts.push(`<span style="color:var(--neon-red)">[RATE DRIFT: UI hint ${rateHint}]</span>`);
                 if (d.auto_cap_frct != null && capHint != null && d.auto_cap_frct !== capHint)
@@ -303,23 +316,28 @@
             (payoutStatus.wallet_status || []).forEach(s => { statusByWallet[s.wallet] = s; });
 
             const rows = (payoutPending.wallets || []).map(w => {
-                const owed = w.unpaid_minutes * rate;
+                // Total debt drives the human-facing figures and the approval
+                // badge; the daemon settles it in per-run batches (served_*).
+                const totalMin = w.total_unpaid_minutes != null ? w.total_unpaid_minutes : w.served_minutes;
+                const owed = totalMin * rate;
+                const approvedMin = w.served_approved_minutes || 0;
                 const invalid = (statusByWallet[w.wallet] || {}).status === 'invalid_address';
+                const truncNote = w.truncated ? ' <span style="color:var(--neon-orange)" title="More unpaid rows than the per-run cap — paid in batches across cycles.">[BATCHED]</span>' : '';
                 let state, actions = '';
                 if (invalid) {
                     state = '<span style="color:var(--neon-red)">INVALID ADDRESS</span>';
                 } else if (owed <= cap) {
                     state = '<span style="color:var(--neon-green)">AUTO</span>';
-                } else if (w.approved_minutes > 0) {
-                    state = `<span style="color:var(--neon-green)">APPROVED ${(w.approved_minutes * rate).toFixed(2)} FRCT</span>`;
+                } else if (approvedMin > 0) {
+                    state = `<span style="color:var(--neon-green)">APPROVED ${(approvedMin * rate).toFixed(2)} FRCT</span>`;
                     actions = `<button data-pay-act="unapprove" data-wallet="${escapeHTML(w.wallet)}" style="border-color:var(--neon-orange); color:var(--neon-orange)">REVOKE</button>`;
                 } else {
                     state = '<span style="color:var(--neon-orange)">NEEDS APPROVAL</span>';
                     actions = `<button data-pay-act="approve" data-wallet="${escapeHTML(w.wallet)}" style="border-color:var(--neon-green); color:var(--neon-green)">APPROVE</button>`;
                 }
                 return `<tr>
-                    <td style="word-break:break-all; font-size:0.82em;" title="${escapeHTML(w.wallet)}">${escapeHTML(w.wallet)}</td>
-                    <td>${w.unpaid_minutes}</td>
+                    <td style="word-break:break-all; font-size:0.82em;" title="${escapeHTML(w.wallet)}">${escapeHTML(w.wallet)}${truncNote}</td>
+                    <td>${escapeHTML(String(totalMin))}</td>
                     <td>${owed.toFixed(2)}</td>
                     <td>${state}</td>
                     <td>${actions}</td>
@@ -360,7 +378,12 @@
                 fetch(`/api/payouts/${action}`, {
                     method: 'POST', headers: {'Content-Type': 'application/json'},
                     body: JSON.stringify({wallet: wallet})
-                }).then(() => refreshAll());
+                }).then(r => {
+                    // Surface CSRF/auth/500 failures — silently swallowing them
+                    // leaves the admin believing an approval succeeded.
+                    if (!r.ok) alert(`Payout ${action} failed: HTTP ${r.status}`);
+                    return refreshAll();
+                }).catch(() => alert(`Payout ${action} failed: network error`));
                 return;
             }
             const copyBtn = e.target.closest('[data-copy-txid]');

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -156,6 +156,44 @@
             </div>
         </div>
 
+        <div class="card" style="border-color: var(--neon-green); margin-top: 20px;">
+            <div class="card-header" style="border-color: var(--neon-green);">
+                <h3 style="color:var(--neon-green)">>> FRACTUM_PAYOUTS</h3>
+                <span id="payout-daemon-strip" style="font-size:0.78em; color:var(--text-dim);"></span>
+            </div>
+            <div class="scroll-box" style="max-height: 300px;">
+                <table>
+                    <thead>
+                        <tr>
+                            <th width="34%">WALLET</th>
+                            <th width="14%">UNPAID MIN</th>
+                            <th width="14%">FRCT OWED</th>
+                            <th width="18%">STATE</th>
+                            <th width="20%">ACTIONS</th>
+                        </tr>
+                    </thead>
+                    <tbody id="payout-wallet-list"></tbody>
+                </table>
+            </div>
+            <div class="card-header" style="border-top: 1px dashed var(--neon-green); border-bottom: none;">
+                <h3 style="color:var(--neon-green); font-size:0.85em;">PAID HISTORY</h3>
+            </div>
+            <div class="scroll-box" style="max-height: 220px;">
+                <table>
+                    <thead>
+                        <tr>
+                            <th width="16%">TIME</th>
+                            <th width="30%">WALLET</th>
+                            <th width="12%">FRCT</th>
+                            <th width="10%">MODE</th>
+                            <th width="32%">TXID</th>
+                        </tr>
+                    </thead>
+                    <tbody id="payout-history-list"></tbody>
+                </table>
+            </div>
+        </div>
+
         <div class="toolbar" style="margin-top: 30px;">
             <div class="label">LOG LEVEL:</div>
             <div class="toolbar-group">
@@ -198,10 +236,136 @@
         }
 
         async function refreshAll() {
-            await Promise.all([loadJobs(), loadLogs(), loadErrorReports(), loadConfig()]);
+            await Promise.all([loadJobs(), loadLogs(), loadErrorReports(), loadConfig(), loadPayouts()]);
             applyFilters();
             renderErrorReports();
+            renderPayouts();
         }
+
+        let payoutPending = null;
+        let payoutStatus = null;
+        let payoutNoWalletMinutes = 0;
+
+        async function loadPayouts() {
+            try {
+                const [pR, sR, eR] = await Promise.all([
+                    fetch('/api/payouts/pending'),
+                    fetch('/api/payouts/status'),
+                    fetch('/api/earnings?limit=1')
+                ]);
+                payoutPending = await pR.json();
+                payoutStatus = await sR.json();
+                const earn = await eR.json();
+                const nw = (earn.wallets || []).find(w => w.wallet === '(no wallet)');
+                payoutNoWalletMinutes = nw ? nw.unpaid_minutes : 0;
+            } catch(e) { payoutPending = null; payoutStatus = null; }
+        }
+
+        function renderPayouts() {
+            const strip = document.getElementById('payout-daemon-strip');
+            const tbody = document.getElementById('payout-wallet-list');
+            const hist = document.getElementById('payout-history-list');
+            if (!strip || !tbody || !hist) return;
+            if (!payoutPending || !payoutStatus) {
+                strip.textContent = '// PAYOUT API UNAVAILABLE //';
+                return;
+            }
+
+            const d = payoutStatus.daemon;
+            const rateHint = payoutStatus.rate_hint_frct_per_min;
+            const capHint = payoutStatus.auto_cap_hint_frct;
+            // The daemon's config is authoritative for money — display its
+            // values when it has reported in, and warn on drift vs our hints.
+            const rate = (d && d.rate_frct_per_min != null) ? d.rate_frct_per_min : rateHint;
+            const cap = (d && d.auto_cap_frct != null) ? d.auto_cap_frct : capHint;
+
+            if (!d) {
+                strip.innerHTML = '<span style="color:var(--neon-orange)">DAEMON: NEVER REPORTED</span>';
+            } else {
+                const ageMin = d.received_at ? Math.round((Date.now() - new Date(d.received_at).getTime()) / 60000) : null;
+                const stale = ageMin == null || ageMin > 30;
+                let parts = [];
+                parts.push(`<span style="color:${stale ? 'var(--neon-red)' : 'var(--neon-green)'}">HEARTBEAT ${ageMin == null ? '?' : ageMin + 'm ago'}</span>`);
+                if (d.dry_run) parts.push('<span style="color:var(--neon-orange)">[DRY RUN]</span>');
+                if (d.paused) parts.push('<span style="color:var(--neon-red)">[PAUSED]</span>');
+                if (d.treasury_frct != null) parts.push(`TREASURY ${d.treasury_frct} FRCT`);
+                parts.push(`RATE ${rate} FRCT/min`);
+                parts.push(`AUTO CAP ${cap} FRCT`);
+                if (d.rate_frct_per_min != null && rateHint != null && d.rate_frct_per_min !== rateHint)
+                    parts.push(`<span style="color:var(--neon-red)">[RATE DRIFT: UI hint ${rateHint}]</span>`);
+                if (d.auto_cap_frct != null && capHint != null && d.auto_cap_frct !== capHint)
+                    parts.push(`<span style="color:var(--neon-red)">[CAP DRIFT: UI hint ${capHint}]</span>`);
+                if (d.last_error) parts.push(`<span style="color:var(--neon-red)" title="${escapeHTML(String(d.last_error))}">[ERROR]</span>`);
+                strip.innerHTML = parts.join(' &nbsp;|&nbsp; ');
+            }
+
+            const statusByWallet = {};
+            (payoutStatus.wallet_status || []).forEach(s => { statusByWallet[s.wallet] = s; });
+
+            const rows = (payoutPending.wallets || []).map(w => {
+                const owed = w.unpaid_minutes * rate;
+                const invalid = (statusByWallet[w.wallet] || {}).status === 'invalid_address';
+                let state, actions = '';
+                if (invalid) {
+                    state = '<span style="color:var(--neon-red)">INVALID ADDRESS</span>';
+                } else if (owed <= cap) {
+                    state = '<span style="color:var(--neon-green)">AUTO</span>';
+                } else if (w.approved_minutes > 0) {
+                    state = `<span style="color:var(--neon-green)">APPROVED ${(w.approved_minutes * rate).toFixed(2)} FRCT</span>`;
+                    actions = `<button data-pay-act="unapprove" data-wallet="${escapeHTML(w.wallet)}" style="border-color:var(--neon-orange); color:var(--neon-orange)">REVOKE</button>`;
+                } else {
+                    state = '<span style="color:var(--neon-orange)">NEEDS APPROVAL</span>';
+                    actions = `<button data-pay-act="approve" data-wallet="${escapeHTML(w.wallet)}" style="border-color:var(--neon-green); color:var(--neon-green)">APPROVE</button>`;
+                }
+                return `<tr>
+                    <td style="word-break:break-all; font-size:0.82em;" title="${escapeHTML(w.wallet)}">${escapeHTML(w.wallet)}</td>
+                    <td>${w.unpaid_minutes}</td>
+                    <td>${owed.toFixed(2)}</td>
+                    <td>${state}</td>
+                    <td>${actions}</td>
+                </tr>`;
+            });
+            if (payoutNoWalletMinutes > 0) {
+                rows.push(`<tr style="color:#555;">
+                    <td>(no wallet)</td><td>${payoutNoWalletMinutes}</td><td>-</td>
+                    <td>UNPAYABLE</td><td></td>
+                </tr>`);
+            }
+            tbody.innerHTML = rows.length ? rows.join('') :
+                '<tr><td colspan="5" style="text-align:center; color:#555;">// NOTHING OWED //</td></tr>';
+
+            const history = payoutStatus.history || [];
+            hist.innerHTML = history.length ? history.map(h => `<tr>
+                    <td style="color:#666; font-size:0.85em;">${fmtTs(h.created_at)}</td>
+                    <td style="word-break:break-all; font-size:0.82em;">${escapeHTML(h.wallet)}</td>
+                    <td>${h.frct}</td>
+                    <td style="color:#888; font-size:0.8em;">${escapeHTML(h.mode || '')}</td>
+                    <td style="font-size:0.78em; color:#888;">
+                        <span title="${escapeHTML(h.txid || '')}">${escapeHTML((h.txid || '-').slice(0, 20))}${(h.txid || '').length > 20 ? '…' : ''}</span>
+                        ${h.txid ? `<button data-copy-txid="${escapeHTML(h.txid)}" style="font-size:0.8em; padding:1px 5px;">COPY</button>` : ''}
+                    </td>
+                </tr>`).join('') :
+                '<tr><td colspan="5" style="text-align:center; color:#555;">// NO PAYOUTS YET //</td></tr>';
+        }
+
+        document.addEventListener('click', (e) => {
+            const payBtn = e.target.closest('[data-pay-act]');
+            if (payBtn) {
+                const action = payBtn.dataset.payAct;
+                const wallet = payBtn.dataset.wallet;
+                const msg = action === 'approve'
+                    ? `Approve payout of ALL current unpaid earnings for wallet\n${wallet}?\n(New work after this stays unapproved.)`
+                    : `Revoke payout approval for wallet\n${wallet}?`;
+                if (!confirm(msg)) return;
+                fetch(`/api/payouts/${action}`, {
+                    method: 'POST', headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({wallet: wallet})
+                }).then(() => refreshAll());
+                return;
+            }
+            const copyBtn = e.target.closest('[data-copy-txid]');
+            if (copyBtn) navigator.clipboard.writeText(copyBtn.dataset.copyTxid);
+        });
 
         async function loadConfig() {
             try {


### PR DESCRIPTION
## Summary

The earnings ledger has accrued verified minutes per wallet since the rewards groundwork landed, but nothing ever wrote the `paid` flag. This PR adds the manager half of actual coin payouts. The other half — the payout daemon that runs on the Pi next to the coin wallet — is in the FractumCoin repo (`encode-rewards/`, companion PR on the same branch name).

## Changes

**Schema (additive + idempotent, safe for the auto-update deploy):**
- `earnings`: new `approved`, `paid_txid`, `paid_at` columns and an unpaid index
- new `payouts` (settlement history), `payout_wallet_status` (daemon-reported invalid addresses), `payout_meta` (heartbeat) tables

**Auth:** new `PAYOUT_TOKEN` config + `requires_payout_auth` decorator (`X-Payout-Token` header, `compare_digest`, admin Basic fallback; `None` disables the token path).

**Endpoints:**
- `GET /api/payouts/pending` — unpaid rows grouped by wallet, oldest-first, `NULL`/empty wallets excluded, approved ids broken out for hybrid mode
- `POST /api/payouts/mark_paid` — idempotent settlement: `paid=0` + wallet guards, IN-lists chunked at 500 params, no duplicate history on re-push, immediate RAM-DB flush (paid flags are money-critical)
- `POST /api/payouts/approve` / `unapprove` — admin snapshot approval for over-cap wallets; added to the CSRF origin check since Basic-auth browsers auto-send credentials
- `POST /api/payouts/report` + `GET /api/payouts/status` — daemon heartbeat and invalid-address surfacing

**Admin UI:** new `FRACTUM_PAYOUTS` card — daemon health strip (heartbeat age, dry-run/paused badges, treasury balance, rate/cap drift warning), per-wallet owed table with AUTO / NEEDS APPROVAL / INVALID ADDRESS badges and approve buttons, paid history with txids.

`PAYOUT_RATE_FRCT_PER_MIN` / `PAYOUT_AUTO_CAP_FRCT` are UI display hints only; the daemon's config is authoritative for money movement.

## Testing

Ran the manager locally (`DB_MODE='disk'`, fixture ledger with NULL-wallet, empty-wallet, under-cap and over-cap balances) and exercised every endpoint with curl plus a full daemon run against a stub RPC:
- pending excludes NULL/empty wallets; over-cap wallet exposes ids only after approve
- `mark_paid` twice with the same body → `updated=2` then `updated=0`, both 200, exactly one history row; wrong-wallet ids update nothing
- approve without matching Origin → 403; missing/wrong token → 401
- simulated RAM-DB revert (`paid=1` flipped back to 0) → daemon re-pushes the settlement, rows re-flip with the original txid, no duplicate history
- restart against the pre-migration DB → idempotent ALTERs apply cleanly; `/admin` renders

⚠️ Note for deploy: `MANAGER_AUTO_UPDATE` will self-deploy this within 6h of merging. The payout API is inert until `PAYOUT_TOKEN` is set in `config.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sSGuWe3Cvk1bZK3HBLpBb

---
_Generated by [Claude Code](https://claude.ai/code/session_019sSGuWe3Cvk1bZK3HBLpBb)_