### PR TITLE
Windows one-liner installer: `irm /install/windows | iex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Open **PowerShell** (no admin needed) and paste:
 irm https://encode.fractumseraph.net/install/windows | iex
 ```
 
-The script asks for a username (which is also used as the worker's name), installs Python 3.11 per-user if it is missing, downloads the worker into `%USERPROFILE%\FractumWorker`, and starts it. FFmpeg (~40 MB portable build) and the TUI library are fetched automatically on first run.
+The script asks for a username and a worker name (press Enter to use the computer's name), installs Python 3.11 per-user if it is missing, downloads the worker into `%USERPROFILE%\FractumWorker`, and starts it. FFmpeg (~40 MB portable build) and the TUI library are fetched automatically on first run.
 
-- Re-run the same line any time to update and restart the worker — the identity saved in `worker_config.json` is reused, so it only asks for a username once.
+- Re-run the same line any time to update and restart the worker — the identity saved in `worker_config.json` is reused, so it only asks once.
 - Append `?jobs=2` or `?series_id=X` (combine with `&`) to the URL to run more parallel jobs or focus on one series.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -94,7 +94,21 @@ Append `&series_id=X` to focus on a specific series.
 
 ---
 
-### Option 3: Windows (Manual)
+### Option 3: Windows (One-liner)
+
+Open **PowerShell** (no admin needed) and paste:
+
+```powershell
+irm https://encode.fractumseraph.net/install/windows | iex
+```
+
+The script asks for a username (which is also used as the worker's name), installs Python 3.11 per-user if it is missing, downloads the worker into `%USERPROFILE%\FractumWorker`, and starts it. FFmpeg (~40 MB portable build) and the TUI library are fetched automatically on first run.
+
+- Re-run the same line any time to update and restart the worker — the identity saved in `worker_config.json` is reused, so it only asks for a username once.
+- Append `?jobs=2` or `?series_id=X` (combine with `&`) to the URL to run more parallel jobs or focus on one series.
+
+<details>
+<summary><b>Manual setup</b> (if you'd rather not pipe a script into your shell)</summary>
 
 1. **Install Python 3.11+** from [python.org](https://www.python.org/).  
    During installation, check **"Add Python to PATH"**.
@@ -114,6 +128,8 @@ Append `&series_id=X` to focus on a specific series.
    ```
 
    > FFmpeg is downloaded automatically (~40 MB portable build) if it is not found on the system.
+
+</details>
 
 ---
 

--- a/manager.py
+++ b/manager.py
@@ -1947,18 +1947,22 @@ $WorkDir = Join-Path $env:USERPROFILE "FractumWorker"
 New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
 Set-Location $WorkDir
 
-# --- 1. Username (doubles as the worker name); skipped when a saved config exists ---
+# --- 1. Username + worker name (defaults to this computer's name); skipped when a saved config exists ---
 $UserArgs = @()
 if (Test-Path "worker_config.json") {
     Write-Host "[*] Found worker_config.json - reusing the saved identity." -ForegroundColor Green
 } else {
     $FractumUser = ""
     while ([string]::IsNullOrWhiteSpace($FractumUser)) {
-        $FractumUser = Read-Host "Enter a username (it will also be this worker's name)"
+        $FractumUser = Read-Host "Enter a username"
     }
     $FractumUser = $FractumUser -replace '[^a-zA-Z0-9_.-]', ''
     if ([string]::IsNullOrWhiteSpace($FractumUser)) { $FractumUser = "Anonymous" }
-    $UserArgs = @("--username", $FractumUser, "--workername", $FractumUser)
+    $WorkerName = Read-Host "Enter a name for this worker (press Enter to use '$env:COMPUTERNAME')"
+    if ([string]::IsNullOrWhiteSpace($WorkerName)) { $WorkerName = "$env:COMPUTERNAME" }
+    $WorkerName = $WorkerName -replace '[^a-zA-Z0-9_.-]', ''
+    if ([string]::IsNullOrWhiteSpace($WorkerName)) { $WorkerName = "WindowsNode" }
+    $UserArgs = @("--username", $FractumUser, "--workername", $WorkerName)
 }
 
 # --- 2. Find or install Python 3 ---
@@ -2008,9 +2012,10 @@ def install_script_windows():
     """Windows one-liner:  irm https://<manager>/install/windows | iex
 
     Unlike /install there are no username/workername query params — the script
-    prompts for a username interactively and uses it as the worker name too
-    (saved to worker_config.json, so re-runs skip the prompt). jobs, series_id
-    and wallet behave the same as on /install."""
+    prompts for a username interactively, and for a worker name that defaults
+    to the machine's $env:COMPUTERNAME (saved to worker_config.json, so re-runs
+    skip the prompts). jobs, series_id and wallet behave the same as on
+    /install."""
     j = request.args.get('jobs', '1')
     if not j.isdigit(): j = '1'
     s_id = request.args.get('series_id', '')

--- a/manager.py
+++ b/manager.py
@@ -1932,6 +1932,100 @@ python3 worker.py --username "{u}" --workername "{w}" --jobs {j} --manager "{SER
 """
     return Response(script, mimetype='text/x-shellscript')
 
+# PowerShell twin of /install. Kept as a plain string with __PLACEHOLDER__
+# substitution because the script's own braces would collide with an f-string.
+WINDOWS_INSTALL_PS = r"""# Fractum Worker - Windows bootstrap (served by the manager)
+# Usage:  irm __BASE__/install/windows | iex
+$ErrorActionPreference = "Stop"
+
+Write-Host ""
+Write-Host "=== Fractum Distributed Encoder :: Worker Setup ===" -ForegroundColor Cyan
+Write-Host ""
+
+# Everything lives in ~\FractumWorker so re-running the one-liner resumes this worker.
+$WorkDir = Join-Path $env:USERPROFILE "FractumWorker"
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+Set-Location $WorkDir
+
+# --- 1. Username (doubles as the worker name); skipped when a saved config exists ---
+$UserArgs = @()
+if (Test-Path "worker_config.json") {
+    Write-Host "[*] Found worker_config.json - reusing the saved identity." -ForegroundColor Green
+} else {
+    $FractumUser = ""
+    while ([string]::IsNullOrWhiteSpace($FractumUser)) {
+        $FractumUser = Read-Host "Enter a username (it will also be this worker's name)"
+    }
+    $FractumUser = $FractumUser -replace '[^a-zA-Z0-9_.-]', ''
+    if ([string]::IsNullOrWhiteSpace($FractumUser)) { $FractumUser = "Anonymous" }
+    $UserArgs = @("--username", $FractumUser, "--workername", $FractumUser)
+}
+
+# --- 2. Find or install Python 3 ---
+function Find-Python {
+    foreach ($c in @("python", "python3", "py")) {
+        # The Microsoft Store stub prints "Python was not found..." so the
+        # match filters it out; 2>&1 under EAP=Stop can throw, hence try/catch.
+        try { if ("$(& $c --version 2>&1)" -match "Python 3") { return $c } } catch {}
+    }
+    $LocalPy = Join-Path $env:LOCALAPPDATA "Programs\Python\Python311\python.exe"
+    if (Test-Path $LocalPy) { return $LocalPy }
+    return $null
+}
+$Py = Find-Python
+if (-not $Py) {
+    Write-Host "[*] Python 3 not found - installing Python 3.11 for the current user (1-2 min)..." -ForegroundColor Yellow
+    $Installer = Join-Path $env:TEMP "python_installer.exe"
+    Invoke-WebRequest "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" -OutFile $Installer -UseBasicParsing
+    Start-Process -FilePath $Installer -ArgumentList "/quiet InstallAllUsers=0 PrependPath=1 Include_test=0" -Wait
+    Remove-Item $Installer -ErrorAction SilentlyContinue
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "User") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "Machine")
+    $Py = Find-Python
+    if (-not $Py) {
+        Write-Host "[!] Automatic Python install failed. Install Python 3 from https://www.python.org (check 'Add python.exe to PATH'), then re-run this command." -ForegroundColor Red
+        return
+    }
+}
+Write-Host "[*] Using $("$(& $Py --version 2>&1)".Trim())" -ForegroundColor Green
+
+# --- 3. Base dependency (the worker self-installs the TUI and FFmpeg on first run) ---
+& $Py -m pip install --disable-pip-version-check --quiet requests | Out-Null
+
+# --- 4. Download the latest worker ---
+Write-Host "[*] Downloading worker.py..."
+Invoke-WebRequest "__BASE__/dl/worker" -OutFile "worker.py" -UseBasicParsing
+
+# --- 5. Run it ---
+$env:WORKER_SECRET = '__SECRET__'
+Write-Host "[*] Starting worker (press 'q' in the TUI or Ctrl+C to stop)..." -ForegroundColor Cyan
+$RunArgs = @("worker.py", "--manager", "__MANAGER__", "--jobs", "__JOBS__"__EXTRA__) + $UserArgs
+& $Py @RunArgs
+"""
+
+@app.route('/install/windows')
+@app.route('/install.ps1')
+def install_script_windows():
+    """Windows one-liner:  irm https://<manager>/install/windows | iex
+
+    Unlike /install there are no username/workername query params — the script
+    prompts for a username interactively and uses it as the worker name too
+    (saved to worker_config.json, so re-runs skip the prompt). jobs, series_id
+    and wallet behave the same as on /install."""
+    j = request.args.get('jobs', '1')
+    if not j.isdigit(): j = '1'
+    s_id = request.args.get('series_id', '')
+    if s_id and not s_id.isdigit(): s_id = ''
+    wallet = sanitize_wallet(request.args.get('wallet'))
+    extra = f', "--series-id", "{s_id}"' if s_id else ''
+    if wallet: extra += f', "--wallet", "{wallet}"'
+    script = (WINDOWS_INSTALL_PS
+              .replace('__BASE__', SERVER_URL_DISPLAY.rstrip('/'))
+              .replace('__MANAGER__', SERVER_URL_DISPLAY)
+              .replace('__SECRET__', WORKER_SECRET.replace("'", "''"))
+              .replace('__JOBS__', j)
+              .replace('__EXTRA__', extra))
+    return Response(script, mimetype='text/plain')
+
 @app.route('/download_source/<path:filename>')
 @requires_worker_auth
 def download_source(filename):

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -262,7 +262,14 @@
                 </div>
                 
                 <div class="os-section">
-                    <span class="os-title">:: WINDOWS / MANUAL</span>
+                    <span class="os-title">:: WINDOWS (ONE-LINER)</span>
+                    Open PowerShell and run this. It asks for your username, then installs everything and starts encoding:
+                    <code id="win-cmd">Loading...</code>
+                    <p style="font-size:0.8em; color:#888; margin-top:5px;">To focus on a series, append <code>?series_id=X</code> to the URL. Re-run the same line to restart the worker later.</p>
+                </div>
+
+                <div class="os-section">
+                    <span class="os-title">:: MANUAL</span>
                     1. Download the script below.<br>
                     2. Install Python 3 & FFmpeg (with SVT-AV1).<br>
                     3. Run: <code>python worker.py --manager <span id="mgr-url">...</span></code>
@@ -298,6 +305,7 @@
         function openModal() { 
             const url = window.location.origin;
             document.getElementById('linux-cmd').innerText = `curl -s "${url}/install?username=User&workername=Box1" | sudo bash`;
+            document.getElementById('win-cmd').innerText = `irm ${url}/install/windows | iex`;
             document.getElementById('mgr-url').innerText = url;
             document.getElementById('helpModal').style.display = 'flex'; 
         }


### PR DESCRIPTION
## Summary

Windows volunteers can now be told: **"Open PowerShell and run this."**

```powershell
irm https://encode.fractumseraph.net/install/windows | iex
```

Adds a `/install/windows` route to the manager (also aliased as `/install.ps1`) — the PowerShell twin of the existing Linux `/install` bash route. The served script:

1. **Asks for a username** (`Read-Host`, sanitized with the same charset as the manager) and **a worker name that defaults to the computer's name** — pressing Enter uses `$env:COMPUTERNAME`, so two PCs run by the same user never collide on identical worker IDs
2. **Installs Python 3.11** per-user (no admin/UAC) if no working Python 3 is found — the detection filters out the Microsoft Store `python.exe` stub
3. **Installs `requests`** via pip (the only import the worker needs before its own bootstrap takes over — textual and FFmpeg are self-installed by the worker on first run)
4. **Downloads `worker.py`** from `/dl/worker` into `%USERPROFILE%\FractumWorker`
5. **Sets `WORKER_SECRET`** (embedded server-side, same policy as `/install` and `/web`) and **runs the worker** in the current console

Re-running the same one-liner reuses the identity saved in `worker_config.json` and skips the prompts, so the same line doubles as "update and restart the worker."

Query params mirror the Linux route where they make sense: `?jobs=N`, `?series_id=X`, `?wallet=ADDR` (username/workername are interactive by design).

Because the command is `irm | iex` (never a `.ps1` file on disk), it runs even under the default `Restricted` execution policy.

## Other changes

- **README**: Option 3 (Windows) now leads with the one-liner; the manual steps are kept in a collapsed `<details>` block
- **Dashboard deploy modal**: added a `:: WINDOWS (ONE-LINER)` section with the command built from `window.location.origin`, matching the Linux section

## Notes

- The endpoint only works once the updated `manager.py` is deployed/restarted at `encode.fractumseraph.net`.