### PR TITLE
Add optimized Kaggle worker notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ Use `fractum-worker.service` to run the worker as a persistent background servic
 
 ---
 
+### Option 5: Kaggle Notebook (free cloud CPU)
+
+[`kaggle_worker.ipynb`](kaggle_worker.ipynb) runs the worker on a free Kaggle session for up to ~12 hours per run.
+
+1. On Kaggle: **Create → New Notebook → File → Import Notebook** and upload `kaggle_worker.ipynb`.
+2. In the notebook sidebar: *Internet* → **On**, *Accelerator* → **None** (the encoder is CPU-only — a GPU adds nothing and burns your weekly GPU quota).
+3. Edit the **CONFIG** cell — username, worker name, jobs, optional extra flags.
+4. **Save Version → Save & Run All (Commit)** — the worker runs headless and stops itself gracefully before Kaggle's 12 h session limit. You can close the browser.
+5. Re-run the notebook — or schedule it (*Notebook → Schedule a notebook run*) — to keep contributing.
+
+The notebook runs the worker with `--no-tui` and samples progress lines once a minute so the saved log stays small, keeps temp files out of the size-capped `/kaggle/working`, and skips manual FFmpeg installs entirely (the worker downloads its own `libsvtav1`-capable static build). An optional `WORKER_SECRET` can be supplied via Kaggle's *Add-ons → Secrets* instead of being hardcoded.
+
+---
+
 ### TUI Controls
 
 When running with the Textual TUI (default — installed automatically on first run if not already present):

--- a/kaggle_worker.ipynb
+++ b/kaggle_worker.ipynb
@@ -1,0 +1,65 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "metadata": {
+  "kernelspec": {
+   "language": "python",
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.12",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  },
+  "kaggle": {
+   "accelerator": "none",
+   "dataSources": [],
+   "isInternetEnabled": true,
+   "language": "python",
+   "sourceType": "notebook",
+   "isGpuEnabled": false
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Fractum Distributed Encodes \u2014 Kaggle Worker\n\nRuns a [DistributedEncodes](https://github.com/FractumSeraph/DistributedEncodes) worker on a free Kaggle CPU session.\n\n## Quick start\n\n1. **Settings** (sidebar): *Internet* \u2192 **On**, *Accelerator* \u2192 **None** \u2014 the encoder (SVT-AV1) is CPU-only; a GPU adds nothing and burns your weekly GPU quota.\n2. Edit the **CONFIG** cell below (username, worker name, jobs).\n3. **Save Version \u2192 Save & Run All (Commit)** \u2014 the worker runs headless for ~11.5 h and shuts itself down gracefully before Kaggle's 12 h hard kill. You can close the browser.\n   (Interactive sessions are killed ~40 min after the tab closes, so always use *Save & Run All* for long runs.)\n4. Re-run the notebook \u2014 or schedule it (*Notebook \u2192 Schedule a notebook run*) \u2014 to keep contributing.\n\n## What this notebook does differently\n\n* **No `apt-get` / manual FFmpeg installs.** Apt's FFmpeg 4.4 and johnvansickle's 7.0.x static build both lack `libsvtav1` \u2265 7.1, so the worker rejects them and downloads its own BtbN static build anyway. The old setup spent ~1 min installing FFmpeg twice for nothing.\n* **`--no-tui`.** The Textual TUI in a notebook is just megabytes of ANSI escape codes in the saved output (and can push Kaggle's log past its size limit). Plain logs instead, with `\\r`-style progress lines sampled once a minute.\n* **`textual` + `requests` pre-installed** so the worker's auto-installer doesn't pip-install and re-exec itself mid-start.\n* **Temp files in `/kaggle/tmp`**, not `/kaggle/working` \u2014 working/ is capped at ~20 GB and snapshotted into the notebook output on save, which makes commits slow.\n* **Time-boxed supervisor**: graceful shutdown before the 12 h session limit (so the last chunk isn't lost to a hard kill), crash restarts with backoff, and no fresh launches in the final minutes.\n"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "trusted": true
+   },
+   "source": "# ============================== CONFIG ==============================\nUSERNAME   = \"FractumSeraph\"  # Scoreboard name\nWORKERNAME = \"Kaggle\"         # Identifier for this machine\nJOBS       = 2                # Parallel encode threads. 2 keeps the CPU busy\n                              # while the other job is downloading/uploading.\n\nMAX_RUNTIME_HOURS = 11.5      # Kaggle batch sessions are hard-killed at 12 h \u2014\n                              # stop gracefully before that.\nNO_RELAUNCH_FINAL_MINUTES = 20  # Don't launch a fresh worker this close to the\n                                # deadline; a new job would likely be cut off.\nSTATUS_EVERY_SECS = 60        # How often to echo the workers' progress line\n                              # (keeps 12 h of logs small instead of 2 lines/sec).\n\nEXTRA_ARGS = []               # e.g. [\"--series-id\", \"42\"], [\"--wallet\", \"ADDR\"],\n                              #      [\"--daily-quota\", \"50\"], [\"--max-size-mb\", \"4000\"]\n\n# Optional: store WORKER_SECRET under \"Add-ons -> Secrets\" instead of\n# hardcoding it. Falls back to the worker's built-in default if absent.\nimport os\ntry:\n    from kaggle_secrets import UserSecretsClient\n    os.environ[\"WORKER_SECRET\"] = UserSecretsClient().get_secret(\"WORKER_SECRET\")\n    print(\"[*] WORKER_SECRET loaded from Kaggle secrets.\")\nexcept Exception:\n    pass  # no secret configured \u2014 worker uses its public default\n",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "trusted": true
+   },
+   "source": "# ============================== SETUP ==============================\n# Deliberately absent (dead weight in the old notebook):\n#   * apt-get install ffmpeg      \u2014 apt's 4.4 lacks libsvtav1 >= 7.1; rejected.\n#   * johnvansickle static ffmpeg \u2014 7.0.x, also rejected. worker_template.py\n#     downloads its own BtbN static build with libsvtav1 on first run.\nimport os, subprocess, sys\n\nREPO_URL = \"https://github.com/FractumSeraph/DistributedEncodes.git\"\nBRANCH   = \"main\"\n\n# Keep the repo + multi-GB encode temp files OUT of /kaggle/working:\n# it's capped at ~20 GB and snapshotted into the notebook output on save.\nBASE_DIR = \"/kaggle/tmp\" if os.path.isdir(\"/kaggle\") else os.getcwd()\nos.makedirs(BASE_DIR, exist_ok=True)\nREPO_DIR = os.path.join(BASE_DIR, \"DistributedEncodes\")\n\nprint(\"--- Installing Python deps ---\")\n# Pre-installing textual skips the worker's own pip-install + self-restart.\nsubprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"--upgrade\",\n                \"requests\", \"textual>=0.20\"], check=True)\n\nprint(\"--- Cloning / updating repo ---\")\nif os.path.isdir(os.path.join(REPO_DIR, \".git\")):\n    subprocess.run([\"git\", \"-C\", REPO_DIR, \"fetch\", \"--depth\", \"1\",\n                    \"origin\", BRANCH], check=True)\n    subprocess.run([\"git\", \"-C\", REPO_DIR, \"reset\", \"--hard\",\n                    f\"origin/{BRANCH}\"], check=True)\nelse:\n    subprocess.run([\"git\", \"clone\", \"--depth\", \"1\", \"--branch\", BRANCH,\n                    REPO_URL, REPO_DIR], check=True)\nprint(f\"Repo ready at {REPO_DIR}\")\n",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "trusted": true
+   },
+   "source": "# ============================== RUN ==============================\n# Supervisor for worker_template.py, tuned for Kaggle:\n#   * --no-tui       : plain logs instead of megabytes of ANSI escape codes.\n#   * output pump    : \\r-overwritten status/progress lines are sampled once\n#                      per STATUS_EVERY_SECS so 12 h of logs stays tiny.\n#   * deadline       : graceful stop (SIGINT + pause-menu \"s\") before Kaggle\n#                      hard-kills the session at 12 h.\n#   * crash restarts : exponential backoff; no fresh launches near the deadline.\nimport re, signal, subprocess, threading, time\n\nANSI_RE  = re.compile(r\"\\x1b\\[[0-9;?]*[A-Za-z]\")\nDEADLINE = time.monotonic() + MAX_RUNTIME_HOURS * 3600\nstarted_at = time.time()\n\ndef remaining():\n    return DEADLINE - time.monotonic()\n\ndef _pump(stream):\n    \"\"\"Forward worker output. Normal lines pass through; \\r-overwritten\n    status lines (which never get a newline) are sampled periodically.\"\"\"\n    buf, last_status = b\"\", 0.0\n    while True:\n        chunk = stream.read1(4096)\n        if not chunk:\n            tail = ANSI_RE.sub(\"\", buf.split(b\"\\r\")[-1].decode(\"utf-8\", \"replace\")).strip()\n            if tail:\n                print(tail, flush=True)\n            return\n        buf += chunk\n        while b\"\\n\" in buf:\n            line, buf = buf.split(b\"\\n\", 1)\n            text = ANSI_RE.sub(\"\", line.split(b\"\\r\")[-1].decode(\"utf-8\", \"replace\")).rstrip()\n            if text:\n                print(text, flush=True)\n        if b\"\\r\" in buf:  # unfinished status line \u2014 keep only the newest segment\n            *done, buf = buf.split(b\"\\r\")\n            now = time.monotonic()\n            if now - last_status >= STATUS_EVERY_SECS:\n                for seg in reversed(done):\n                    text = ANSI_RE.sub(\"\", seg.decode(\"utf-8\", \"replace\")).strip()\n                    if text:\n                        print(f\"[status] {text}\", flush=True)\n                        last_status = now\n                        break\n\ndef launch():\n    cmd = [sys.executable, \"-u\", \"worker_template.py\",\n           \"--username\", USERNAME, \"--workername\", WORKERNAME,\n           \"--jobs\", str(JOBS), \"--no-tui\", *EXTRA_ARGS]\n    env = dict(os.environ, PYTHONUNBUFFERED=\"1\", COLUMNS=\"200\")\n    proc = subprocess.Popen(cmd, cwd=REPO_DIR, env=env,\n                            stdin=subprocess.PIPE, stdout=subprocess.PIPE,\n                            stderr=subprocess.STDOUT)\n    t = threading.Thread(target=_pump, args=(proc.stdout,), daemon=True)\n    t.start()\n    return proc, t\n\ndef stop_gracefully(proc, pump_t, grace=120):\n    \"\"\"SIGINT opens the worker's pause menu on stdin; \"s\" = clean abort\n    (kills ffmpeg children, exits 0). Escalate if it doesn't comply.\"\"\"\n    if proc.poll() is not None:\n        return\n    try:\n        proc.send_signal(signal.SIGINT)\n        time.sleep(2)  # let the pause menu come up\n        proc.stdin.write(b\"s\\n\")\n        proc.stdin.flush()\n    except Exception:\n        pass\n    try:\n        proc.wait(timeout=grace)\n    except subprocess.TimeoutExpired:\n        print(\"[!] Worker didn't stop in time \u2014 killing.\", flush=True)\n        proc.kill()\n        proc.wait()\n    pump_t.join(timeout=10)\n\nbackoff, runs = 10, 0\nprint(f\"[*] Worker window: {MAX_RUNTIME_HOURS} h from now.\")\ntry:\n    while remaining() > NO_RELAUNCH_FINAL_MINUTES * 60:\n        runs += 1\n        run_started = time.monotonic()\n        print(f\"[*] Launching worker (run #{runs}, {remaining()/3600:.1f} h left)...\")\n        proc, pump_t = launch()\n        while proc.poll() is None and remaining() > 0:\n            time.sleep(5)\n        if proc.poll() is None:  # deadline hit while still running\n            print(\"[*] Session time limit reached \u2014 stopping worker gracefully...\")\n            stop_gracefully(proc, pump_t)\n            break\n        pump_t.join(timeout=10)\n        healthy = (time.monotonic() - run_started) > 600\n        backoff = 10 if healthy else min(backoff * 2, 300)\n        print(f\"[!] Worker exited with code {proc.returncode}. \"\n              f\"Restarting in {backoff} s...\")\n        time.sleep(min(backoff, max(remaining(), 0)))\nexcept KeyboardInterrupt:\n    print(\"[*] Interrupted \u2014 stopping worker gracefully...\")\n    try:\n        stop_gracefully(proc, pump_t)\n    except NameError:\n        pass\n\nprint(f\"[*] Done. {(time.time() - started_at) / 3600:.2f} h wall time, \"\n      f\"{runs} worker run(s).\")\n",
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
+}


### PR DESCRIPTION
Adds `kaggle_worker.ipynb`, an optimized replacement for the ad-hoc Kaggle notebook used to run a distributed-encodes worker, and documents it as worker **Option 5** in the README.

## What was wasted in the old notebook

- `apt-get update && apt-get install ffmpeg` (~15 s) installed FFmpeg 4.4, which the worker rejects (needs `libsvtav1` ≥ 7.1).
- A second manual install of johnvansickle's static FFmpeg 7.0.x — also rejected for the same reason. The worker then downloaded its own BtbN static build anyway, as visible in the old notebook's saved output.
- The worker's Textual TUI ran inside the notebook, filling the saved output with megabytes of ANSI escape codes (the uploaded notebook was ~180 KB of escape spam for a few seconds of runtime).
- `textual` was pip-installed by the worker mid-start, forcing a process re-exec.
- Temp encode files landed in `/kaggle/working` (capped at ~20 GB and snapshotted into notebook output on save).
- The `while True: !python ...` loop had no time-boxing, so Kaggle's 12 h hard kill would cut an encode off mid-chunk, and no backoff, so a persistent failure would hot-loop.

## What the new notebook does

- **Setup**: one quiet `pip install` of `requests` + `textual>=0.20` (makes the worker's auto-installer a no-op), shallow clone/update of the repo into `/kaggle/tmp`. No FFmpeg installs at all — the worker fetches its own `libsvtav1`-capable build.
- **Run**: a small supervisor around `worker_template.py --no-tui`:
  - Output pump that passes log lines through but samples `\r`-overwritten status/progress lines once per minute, keeping 12 h of logs small.
  - Graceful deadline stop at a configurable `MAX_RUNTIME_HOURS` (default 11.5 h): sends SIGINT, then answers the worker's pause menu with `s` over stdin (clean abort — kills ffmpeg children, exits 0), escalating to kill only if unresponsive.
  - Crash restarts with exponential backoff (10 s → 5 min), reset after a healthy run; no fresh launches in the final 20 minutes.
- **Config cell**: username/workername/jobs/extra flags in one place; `JOBS = 2` by default so one job encodes while the other downloads/uploads. Optional `WORKER_SECRET` via Kaggle *Add-ons → Secrets*.

## Testing

- All code cells validated with `ast.parse`.
- Supervisor logic exercised against a mock worker replicating the real worker's output style (`\r` + `\033[K` status lines, interleaved log lines) and its SIGINT → `Select [c/f/s]:` pause menu: verified passthrough + rate-limited sampling, graceful deadline stop, and crash-restart backoff paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk9nK3oNNS5PNuVCw3QzWh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk9nK3oNNS5PNuVCw3QzWh)_