### PR TITLE
Sweep dead 'paused' jobs — no recovery path ever matched that status

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -3476,7 +3476,7 @@ def admin_action():
                 c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, fail_count=0, chunked=0, chunkable=NULL, started_at=NULL, last_updated=? WHERE status IN ('failed', 'permanently_failed')", (datetime.now(),))
             elif action == 'clear_stale':
                 cutoff = datetime.now() - timedelta(minutes=10)
-                c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, last_updated=?, started_at=NULL WHERE status IN ('processing', 'downloading', 'uploading') AND COALESCE(chunked, 0)=0 AND last_updated < ?", (datetime.now(), cutoff))
+                c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, last_updated=?, started_at=NULL WHERE status IN ('processing', 'downloading', 'uploading', 'paused') AND COALESCE(chunked, 0)=0 AND last_updated < ?", (datetime.now(), cutoff))
                 c.execute("UPDATE chunks SET status='pending', worker_id=NULL, progress=0, last_updated=? WHERE status='processing' AND last_updated < ?", (datetime.now(), cutoff))
                 # A chunked job whose chunks have ALL gone silent is wedged
                 # (e.g. no chunk-capable workers left) — give the admin the
@@ -3579,8 +3579,12 @@ def maintenance_loop():
                 conn = db_handler.get_connection(); cursor = conn.cursor()
                 try:
                     now = datetime.now()
-                    # Whole-file jobs: 4h heartbeat timeout (chunked jobs are handled below)
-                    cursor.execute("SELECT id, filename, last_updated, worker_id FROM jobs WHERE status IN ('processing', 'downloading', 'uploading') AND COALESCE(chunked, 0)=0")
+                    # Whole-file jobs: 4h heartbeat timeout (chunked jobs are handled
+                    # below). 'paused' is included: a genuinely paused worker still
+                    # heartbeats every 30s, so a paused row with a stale timestamp is
+                    # a dead worker — previously nothing ever swept those, and jobs
+                    # sat 'paused' forever once the worker vanished.
+                    cursor.execute("SELECT id, filename, last_updated, worker_id FROM jobs WHERE status IN ('processing', 'downloading', 'uploading', 'paused') AND COALESCE(chunked, 0)=0")
                     for row in cursor.fetchall():
                         jid, fname, last_up, worker_id = row
                         if last_up:
@@ -3618,8 +3622,11 @@ def maintenance_loop():
                     # nothing to protect: requeue immediately as before. Either
                     # way completed uploads survive on disk for a later re-split.
                     dead_cutoff = now - timedelta(hours=6)
+                    # 'paused' included: a chunked job should never be paused (the
+                    # report_status guards forbid it now), but rows written before
+                    # those guards existed can carry the state forever otherwise.
                     cursor.execute("SELECT id, COALESCE(chunk_stall_count, 0) FROM jobs "
-                                   "WHERE COALESCE(chunked, 0)=1 AND status='processing' AND last_updated < ?",
+                                   "WHERE COALESCE(chunked, 0)=1 AND status IN ('processing', 'paused') AND last_updated < ?",
                                    (dead_cutoff,))
                     for jid, stalls in cursor.fetchall():
                         cursor.execute("SELECT COUNT(*) FROM chunks WHERE job_id=? AND status='completed'", (jid,))
@@ -3627,7 +3634,7 @@ def maintenance_loop():
                         if completed > 0 and stalls < 3:
                             cursor.execute("UPDATE chunks SET status='pending', worker_id=NULL, progress=0, "
                                            "last_updated=? WHERE job_id=? AND status='processing'", (now, jid))
-                            cursor.execute("UPDATE jobs SET chunk_stall_count=?, last_updated=? WHERE id=?",
+                            cursor.execute("UPDATE jobs SET status='processing', chunk_stall_count=?, last_updated=? WHERE id=?",
                                            (stalls + 1, now, jid))
                             conn.commit()
                             log_event("WARN", f"No chunk activity for 6h — holding job with {completed} "


### PR DESCRIPTION
## Problem

The live server has **27 jobs stuck in `paused`** — some since March, held by workers that no longer exist (`Corsair`, `FractumG14`, old `TestWorker` runs on v3.0.x, plus one killed Kaggle session). They became visible with the new worker-centric dashboard, but the underlying bug is old: **no recovery path ever matched the `paused` status.** The maintenance 4-hour timeout and admin Clear Stale both swept only `processing`/`downloading`/`uploading`, so once the pausing worker vanished, the job sat paused forever.

## Why sweeping is safe

A genuinely paused worker still heartbeats every 30 seconds (that was built in precisely so pauses don't look dead). A `paused` row with a stale `last_updated` therefore always means the worker is gone.

## Changes

- The maintenance **4h timeout** and admin **Clear Stale** now include `paused`.
- The 6h **chunked backstop** also accepts the anomalous `chunked` + `paused` combination (rows written before the `report_status` guards forbade it) and normalizes the status back to `processing` when holding the job — banked chunks preserved as usual.

## Verification

Against the real maintenance loop on a live manager: a months-old paused job was requeued on the next tick; a freshly-paused job (recent heartbeat) was left untouched; a chunked+paused anomaly was normalized to `processing`, held (stall 1/3), and kept its completed chunk.

After deploy, the 27 stuck jobs requeue themselves on the first maintenance tick — no manual cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_