### PR TITLE
Windows mirror fallback: try candidates' original filenames on the mirror

### DIFF
--- a/worker_template.py
+++ b/worker_template.py
@@ -113,7 +113,7 @@ except ImportError as _e:
 DEFAULT_MANAGER_URL = "https://encode.fractumseraph.net/"
 DEFAULT_USERNAME = "Anonymous"
 DEFAULT_WORKERNAME = f"Node-{int(time.time())}"
-WORKER_VERSION = "3.4.5"
+WORKER_VERSION = "3.4.6"
 WORKER_SECRET = os.environ.get("WORKER_SECRET", "DefaultInsecureSecret")
 
 SHUTDOWN_EVENT = threading.Event()
@@ -1286,7 +1286,11 @@ def download_ffmpeg_windows():
 
     # Newest release-branch build (discovered) first, hardcoded fallbacks,
     # then the project mirror as a last resort when GitHub is unreachable.
+    # The mirror uses a STABLE alias filename — overwrite that one file with
+    # any current BtbN win64-gpl release zip to refresh it, no code change
+    # needed. (The n7.1 name is the legacy mirror file, kept as a final try.)
     urls = _ffmpeg_candidate_urls() + [
+        "https://vsv.fractumseraph.net/ffmpeg-latest-win64-gpl.zip",
         "https://vsv.fractumseraph.net/ffmpeg-n7.1-latest-win64-gpl-7.1.zip"
     ]
 

--- a/worker_template.py
+++ b/worker_template.py
@@ -1286,12 +1286,14 @@ def download_ffmpeg_windows():
 
     # Newest release-branch build (discovered) first, hardcoded fallbacks,
     # then the project mirror as a last resort when GitHub is unreachable.
-    # The mirror uses a STABLE alias filename — overwrite that one file with
-    # any current BtbN win64-gpl release zip to refresh it, no code change
-    # needed. (The n7.1 name is the legacy mirror file, kept as a final try.)
-    urls = _ffmpeg_candidate_urls() + [
-        "https://vsv.fractumseraph.net/ffmpeg-latest-win64-gpl.zip",
-        "https://vsv.fractumseraph.net/ffmpeg-n7.1-latest-win64-gpl-7.1.zip"
+    # The mirror is tried with each candidate's ORIGINAL filename (so any
+    # current BtbN win64-gpl zip dropped there under its real name works),
+    # then a stable alias, then the legacy n7.1 mirror file.
+    _mirror = "https://vsv.fractumseraph.net/"
+    _cands = _ffmpeg_candidate_urls()
+    urls = _cands + [_mirror + u.rsplit('/', 1)[-1] for u in _cands] + [
+        _mirror + "ffmpeg-latest-win64-gpl.zip",
+        _mirror + "ffmpeg-n7.1-latest-win64-gpl-7.1.zip"
     ]
 
     temp_zip = "ffmpeg_temp.zip"


### PR DESCRIPTION
Follow-up to #31: the Windows mirror fallback pointed at the version-specific `ffmpeg-n7.1-latest-win64-gpl-7.1.zip`, so refreshing the mirror would have needed a code change every time BtbN rotates branches.

The worker (**3.4.6**) now tries the mirror with **each discovery/fallback candidate's original filename** — so dropping any current BtbN win64-gpl zip on the mirror under its real name just works (the freshly uploaded `ffmpeg-n9.0-latest-win64-gpl-9.0.zip` is already live and verified: 200, 169 MB, valid zip magic). A stable alias (`ffmpeg-latest-win64-gpl.zip`) and the legacy n7.1 filename remain as final attempts.

Full Windows fallback order:
1. GitHub, newest discovered release build (currently n9.0)
2. GitHub, hardcoded ladder (9.0 → 8.1)
3. Mirror, same filenames as 1–2
4. Mirror, `ffmpeg-latest-win64-gpl.zip` alias
5. Mirror, legacy n7.1 zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)