### PR TITLE
Don't tear down a chunked job when the assembly ffmpeg is killed mid-shutdown

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -1287,6 +1287,18 @@ def _maybe_start_assembly(job_id):
         ASSEMBLING_JOBS.add(job_id)
     threading.Thread(target=_assemble_job, args=(job_id,), daemon=True).start()
 
+class _AssemblyInterrupted(Exception):
+    """The concat ffmpeg was KILLED rather than failing — almost always the
+    manager itself being stopped (Ctrl+C/SIGTERM reaches child processes).
+    The job's completed chunks must be left alone: the maintenance loop
+    re-triggers assembly automatically (including after a restart)."""
+
+# In-memory interruption counter per job (resets on restart, which is exactly
+# right — a restart is the legitimate interruption case). Bounds the retry
+# loop so a repeat killer (e.g. the OOM reaper hitting every concat) can't
+# re-trigger assembly forever.
+_ASSEMBLY_INTERRUPTS = {}
+
 def _assemble_job(job_id):
     """Concatenate all uploaded video chunks (stream copy — zero quality loss)
     and mux in the audio/subtitle track, then verify and finalize the job."""
@@ -1336,7 +1348,12 @@ def _assemble_job(job_id):
         cmd += ['-c', 'copy', '-movflags', '+faststart', out_tmp]
         res = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
         if res.returncode != 0 or not os.path.exists(out_tmp):
-            raise RuntimeError(f"concat failed (rc={res.returncode}): {res.stderr[-500:] if res.stderr else ''}")
+            err_tail = res.stderr[-500:] if res.stderr else ''
+            # rc 255 / negative rc / "received signal" = ffmpeg was killed,
+            # not a real mux error. Don't tear the job down for that.
+            if res.returncode == 255 or res.returncode < 0 or 'received signal' in err_tail:
+                raise _AssemblyInterrupted(f"concat killed (rc={res.returncode})")
+            raise RuntimeError(f"concat failed (rc={res.returncode}): {err_tail}")
 
         is_valid, reason, _assembled_dur = verify_upload(out_tmp)
         if not is_valid:
@@ -1394,7 +1411,31 @@ def _assemble_job(job_id):
         if warn:
             log_event("WARN", warn, job_id)
         log_event("INFO", f"Chunked job assembled and completed ({len(video_chunks)} chunks by {len(workers)} worker(s)).", job_id)
+        with ASSEMBLY_LOCK:
+            _ASSEMBLY_INTERRUPTS.pop(job_id, None)
 
+    except _AssemblyInterrupted as e:
+        with ASSEMBLY_LOCK:
+            n = _ASSEMBLY_INTERRUPTS.get(job_id, 0) + 1
+            _ASSEMBLY_INTERRUPTS[job_id] = n
+        if n >= 5:
+            # Something keeps killing the concat (OOM?) — stop looping and
+            # hand the job to the whole-file path. Chunk files stay banked.
+            log_event("ERROR", f"Assembly interrupted {n}x ({e}) — giving up on chunked assembly.", job_id)
+            with db_lock:
+                conn = db_handler.get_connection()
+                try:
+                    _requeue_job_whole(conn, job_id, f"assembly interrupted {n}x")
+                    conn.commit()
+                finally:
+                    conn.close()
+        else:
+            # Leave the job and its completed chunks EXACTLY as they are: the
+            # maintenance loop re-triggers assembly for fully-completed chunked
+            # jobs — within a minute if we're still running, or right after
+            # startup when the interruption was the manager being stopped.
+            log_event("WARN", f"Assembly interrupted ({e}) — chunks kept intact; "
+                              f"assembly will retry automatically (attempt {n}/5).", job_id)
     except Exception as e:
         log_event("ERROR", f"Chunk assembly failed: {e}", job_id)
         with db_lock:


### PR DESCRIPTION
## Problem (seen in production during today's update)

Stopping the manager (Ctrl+C) also signals its child processes — including an assembly ffmpeg that was seconds from finishing its faststart pass:

```
[INFO] Handling signal: int
[ERROR] Chunk assembly failed: concat failed (rc=255): ... Exiting normally, received signal 2.
[WARN] Chunked encode abandoned (assembly failed: ...)
```

The killed concat was treated as a *real* assembly failure: fail strike, chunking disabled, job sent to the whole-file queue — a fully-completed chunk set benched because the operator restarted the service at the wrong moment.

## Fix

A **killed** concat (rc 255, negative rc, or `received signal` in stderr) is now an *interruption*, not a failure:

- The job and its completed chunks are left exactly as they are. The existing maintenance re-trigger (fully-completed chunked jobs re-enter assembly) then finishes the file — within a minute if the manager is still running, or right after startup when the interruption *was* the shutdown.
- Genuine mux errors (rc 1 etc.) keep the old teardown path unchanged.
- A per-job in-memory counter (reset on restart — the legitimate case) escalates to the whole-file fallback after **5** interruptions, so a repeat killer (e.g. the OOM reaper) can't loop assembly forever. Even then the chunk files stay banked for a later re-split.

## Verification

With a patched concat subprocess: an rc-255 kill leaves status/chunks/fail_count untouched (and assembly re-runs); an rc-1 real failure tears down exactly as before; five rc=-9 kills escalate to whole-file with the chunk files preserved on disk.

## Note for the job hit today

Its chunk files were preserved (the PR #28 banking was already deployed). After this merges: find the job with the "Chunked encode abandoned (assembly failed: concat failed (rc=255)…" log entry and hit **Retry** in the admin panel — the re-split restores every chunk instantly and assembly completes with no re-encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_