### PR TITLE
Reject silent/double-video encodes; add RE-ENC (delete output + requeue)

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -629,10 +629,13 @@ def requires_payout_auth(f):
         return jsonify({"status": "error", "message": "Unauthorized"}), 401
     return decorated
 
-def verify_upload(filepath):
+def verify_upload(filepath, source_has_audio=None):
     """Validate a finished encode. Returns (ok, reason, duration_sec) — the
     duration comes from ffprobe, so earnings credit is based on what was
-    actually delivered, not on what the worker claims."""
+    actually delivered, not on what the worker claims.
+
+    source_has_audio: True when the SOURCE is known to carry an audio track,
+    so a silent upload can be rejected. None = unknown (skip that check)."""
     try:
         cmd = ['ffprobe', '-v', 'error', '-print_format', 'json', '-show_streams', '-show_format', filepath]
         result = subprocess.run(cmd, capture_output=True, text=True)
@@ -641,16 +644,27 @@ def verify_upload(filepath):
 
         data = json.loads(result.stdout)
         duration = float(data.get('format', {}).get('duration') or 0)
-        has_video = False
+        video_count = 0
+        audio_count = 0
         for stream in data.get('streams', []):
             if stream['codec_type'] == 'video':
                 if stream.get('codec_name') != 'av1': return False, "Invalid Codec (Not AV1)", 0.0
                 if int(stream.get('height', 0)) != 480: return False, "Invalid Height", 0.0
-                has_video = True
+                video_count += 1
             elif stream['codec_type'] == 'audio':
                 if stream.get('codec_name') != 'opus': return False, "Invalid Audio Codec", 0.0
+                audio_count += 1
 
-        if not has_video: return False, "No Video Stream", 0.0
+        if not video_count: return False, "No Video Stream", 0.0
+        # A second video stream is never a valid target layout, and is the
+        # signature of an encode that mapped the video track twice instead of
+        # video+audio (a worker whose probe found no audio index). Those files
+        # verify as "AV1 at 480p" but play SILENTLY — 54 shipped before this
+        # check existed.
+        if video_count > 1:
+            return False, f"Multiple video streams ({video_count}) — audio track was mis-mapped", 0.0
+        if source_has_audio and not audio_count:
+            return False, "No Audio Stream (source has audio)", 0.0
         return True, "Verified", duration
     except Exception as e:
         return False, str(e), 0.0
@@ -665,6 +679,12 @@ def build_download_url(job_id, source_type, source_url):
         base_url = source_url if source_url else REMOTE_SOURCE_URL
         return urljoin(base_url, quote(job_id)) if base_url else ""
     return f"{SERVER_URL_DISPLAY.rstrip('/')}/download_source/{quote(job_id, safe='/')}"
+
+def _completed_path(job_id):
+    """Absolute path of a job's finished encode, or None if the job id would
+    escape COMPLETED_DIRECTORY (path-traversal guard, same as the upload path)."""
+    p = os.path.abspath(os.path.join(COMPLETED_DIRECTORY, os.path.splitext(job_id)[0] + ".mp4"))
+    return p if p.startswith(os.path.abspath(COMPLETED_DIRECTORY) + os.sep) else None
 
 def _chunk_dir(job_id):
     """Directory where uploaded chunks for a job are stored (short + unique)."""
@@ -1308,7 +1328,7 @@ def _assemble_job(job_id):
             conn.row_factory = sqlite3.Row
             try:
                 c = conn.cursor()
-                c.execute("SELECT status, source_duration_sec, total_chunks FROM jobs WHERE id=? AND COALESCE(chunked,0)=1", (job_id,))
+                c.execute("SELECT status, source_duration_sec, total_chunks, stream_meta FROM jobs WHERE id=? AND COALESCE(chunked,0)=1", (job_id,))
                 jrow = c.fetchone()
                 if jrow is None or jrow['status'] != 'processing':
                     return
@@ -1355,7 +1375,13 @@ def _assemble_job(job_id):
                 raise _AssemblyInterrupted(f"concat killed (rc={res.returncode})")
             raise RuntimeError(f"concat failed (rc={res.returncode}): {err_tail}")
 
-        is_valid, reason, _assembled_dur = verify_upload(out_tmp)
+        _src_audio = None
+        if jrow['stream_meta']:
+            try:
+                _src_audio = json.loads(jrow['stream_meta']).get('audio_index') is not None
+            except (TypeError, ValueError):
+                _src_audio = None
+        is_valid, reason, _assembled_dur = verify_upload(out_tmp, source_has_audio=_src_audio)
         if not is_valid:
             raise RuntimeError(f"assembled file failed verification: {reason}")
 
@@ -2675,7 +2701,7 @@ def upload_result():
             conn = db_handler.get_connection()
             try:
                 c = conn.cursor()
-                c.execute("SELECT status, COALESCE(chunked, 0), source_type, source_url, source_duration_sec FROM jobs WHERE id=?", (job_id,))
+                c.execute("SELECT status, COALESCE(chunked, 0), source_type, source_url, source_duration_sec, stream_meta FROM jobs WHERE id=?", (job_id,))
                 jrow = c.fetchone()
             finally:
                 conn.close()
@@ -2691,7 +2717,15 @@ def upload_result():
         temp_path = os.path.join(quarantine_dir, f"{uuid.uuid4().hex}.mp4")
         request.files['file'].save(temp_path)
 
-        is_valid, reason, verified_dur = verify_upload(temp_path)
+        # When the manager's own probe recorded an audio track on the source,
+        # a silent upload is a defect — reject it instead of shipping it.
+        _src_audio = None
+        if len(jrow) > 5 and jrow[5]:
+            try:
+                _src_audio = json.loads(jrow[5]).get('audio_index') is not None
+            except (TypeError, ValueError):
+                _src_audio = None
+        is_valid, reason, verified_dur = verify_upload(temp_path, source_has_audio=_src_audio)
 
         # Length check: a valid-but-TRUNCATED encode (ffmpeg died near the end
         # yet exited 0, a resume glitch, etc.) passes the codec/height check but
@@ -3499,6 +3533,7 @@ def admin_action():
     data = request.json or {}; job_id = data.get('job_id'); action = data.get('action')
     log_event("WARN", f"Admin performed '{action}' on job", job_id)
     post_commit_logs = []
+    purged = None
 
     with db_lock:
         conn = db_handler.get_connection(); c = conn.cursor()
@@ -3512,6 +3547,26 @@ def admin_action():
                 # restores previously-completed uploads instead of re-encoding.
                 c.execute("DELETE FROM chunks WHERE job_id = ?", (job_id,))
                 c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, fail_count=0, chunked=0, chunkable=NULL, started_at=NULL, last_updated=? WHERE id=?", (datetime.now(), job_id))
+            elif action == 'retry_purge':
+                # Retry, but DELETE the finished encode first. For outputs that
+                # passed verification yet are defective (e.g. the worker-3.0.26
+                # batch that muxed the video twice instead of video+audio, so
+                # the file plays silently): the broken file must not survive if
+                # the re-encode never lands, and its banked chunks must not be
+                # restored into the new attempt.
+                _cp = _completed_path(job_id)
+                if _cp and os.path.isfile(_cp):
+                    try:
+                        os.remove(_cp)
+                        post_commit_logs.append(f"Deleted defective output for re-encode: {job_id}")
+                    except OSError as _e:
+                        post_commit_logs.append(f"Could not delete output for {job_id}: {_e}")
+                c.execute("DELETE FROM chunks WHERE job_id = ?", (job_id,))
+                _remove_chunk_dir_async(job_id)
+                c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, fail_count=0, "
+                          "chunked=0, chunkable=NULL, started_at=NULL, chunk_stall_count=0, "
+                          "last_updated=? WHERE id=?", (datetime.now(), job_id))
+                purged = (c.rowcount == 1)
             elif action == 'retry_all_failed':
                 c.execute("DELETE FROM chunks WHERE job_id IN (SELECT id FROM jobs WHERE status IN ('failed', 'permanently_failed'))")
                 c.execute("UPDATE jobs SET status='queued', progress=0, worker_id=NULL, fail_count=0, chunked=0, chunkable=NULL, started_at=NULL, last_updated=? WHERE status IN ('failed', 'permanently_failed')", (datetime.now(),))
@@ -3557,6 +3612,10 @@ def admin_action():
         # FIXED: Run scan in a background thread to prevent client timeout
         threading.Thread(target=scan_and_queue, daemon=True).start()
 
+    if purged is not None:
+        # Report whether the job row actually changed, so bulk callers can
+        # tell a real requeue from a no-op on an unknown/stale job id.
+        return jsonify({"status": "ok", "requeued": purged})
     return jsonify({"status": "ok"})
 
 @app.route('/api/get_config')

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -531,6 +531,11 @@
                     if (j.status === 'failed' || j.status === 'permanently_failed' || j.status === 'completed') {
                         actions = `<button data-act="retry" data-id="${escapeHTML(j.id)}" style="border-color:var(--neon-green); color:var(--neon-green)">RETRY</button> ` + actions;
                     }
+                    // RE-ENC deletes the finished encode first — for outputs that
+                    // passed verification but are defective (e.g. silent files).
+                    if (j.status === 'completed') {
+                        actions = `<button data-act="retry_purge" data-id="${escapeHTML(j.id)}" style="border-color:var(--neon-orange); color:var(--neon-orange)" title="Delete the finished encode and re-encode from source">RE-ENC</button> ` + actions;
+                    }
                     actions += ` <button data-act="log" data-id="${escapeHTML(j.id)}" style="border-color:#555; color:#888; font-size:0.75em;">LOG</button>`;
 
                     // NEW: Build warning badge
@@ -602,6 +607,7 @@
             if (action === 'archive_history') msg = "ARCHIVE ALL HISTORY? This will force a re-encode of ALL files.";
             if (action === 'purge_queue') msg = "DELETE ALL QUEUED JOBS? (They will come back if files exist on disk)";
             if (action === 'clear_error_reports') msg = "Clear ALL error reports?";
+            if (action === 'retry_purge') msg = "DELETE this job's finished encode and re-encode it from source?";
 
             if(!confirm(msg)) return;
             fetch('/api/admin_action', {

--- a/worker_template.py
+++ b/worker_template.py
@@ -113,7 +113,7 @@ except ImportError as _e:
 DEFAULT_MANAGER_URL = "https://encode.fractumseraph.net/"
 DEFAULT_USERNAME = "Anonymous"
 DEFAULT_WORKERNAME = f"Node-{int(time.time())}"
-WORKER_VERSION = "3.4.7"
+WORKER_VERSION = "3.4.8"
 WORKER_SECRET = os.environ.get("WORKER_SECRET", "DefaultInsecureSecret")
 
 SHUTDOWN_EVENT = threading.Event()
@@ -2213,7 +2213,7 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                     # Encode the remainder starting from _r_p1_dur
                     _r_hdrs  = f"X-Worker-Token: {WORKER_SECRET}\r\n"
                     _r_dl    = _r_chk.get('dl_url', '')
-                    _r_ai    = _r_chk.get('audio_index', 0)
+                    _r_ai    = _r_chk.get('audio_index')  # None = source has no audio
                     _r_si    = _r_chk.get('subtitle_indices', [])
                     _r_vf    = _r_chk.get('video_filter', ENCODING_CONFIG['VIDEO_SCALE'])
                     _r_af    = _r_chk.get('audio_filter', 'aresample=async=1')
@@ -2233,7 +2233,8 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                     )
                     _r_rem_cmd = (
                         [FFMPEG_CMD] + _r_input_args
-                        + ['-map', '0:v:0', '-map', f'0:{_r_ai}']
+                        + ['-map', '0:v:0']
+                        + (['-map', f'0:{_r_ai}'] if _r_ai is not None else [])
                         + [x for idx in _r_si for x in ['-map', f'0:{idx}']]
                         + ['-fps_mode', 'passthrough', '-avoid_negative_ts', 'make_zero',
                            '-c:v', ENCODING_CONFIG["VIDEO_CODEC"],
@@ -2536,7 +2537,10 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                         # "pending" or "error" → server has no hash yet, proceed normally
                 # -------------------------------------------------------
 
-                total_sec = 0; total_min = 0; audio_index = 0; subtitle_indices = []
+                # audio_index None = "no audio track". It must NOT default to 0:
+                # stream 0 is the video, and mapping it as audio produced silent
+                # files with two video streams (see the audio_map guard below).
+                total_sec = 0; total_min = 0; audio_index = None; subtitle_indices = []
                 meta_audio_channels = None
                 # Reset every job: a stale probe_data surviving from the previous
                 # loop iteration must never satisfy the failure check below.
@@ -2574,7 +2578,7 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                         # Start each attempt clean so a partially-parsed failure
                         # can't leave duplicate subtitle maps or a half-set state.
                         probe_data = None
-                        audio_index = 0; subtitle_indices = []
+                        audio_index = None; subtitle_indices = []
                         if _is_local:
                             cmd_probe = [FFPROBE_CMD,
                                 '-v', 'quiet', '-print_format', 'json', '-show_streams', '-show_format', dl_url]
@@ -2689,15 +2693,24 @@ def worker_task(worker_id, manager_url, temp_dir, quota_tracker, single_mode=Fal
                 else:
                     target_crf = base_crf
 
+                # Map the audio track ONLY when the source actually has one.
+                # audio_index defaults to 0, so an audio-less source (or a
+                # probe that found no audio streams) used to emit
+                # '-map 0:v:0 -map 0:0' — the VIDEO mapped twice. Those files
+                # still verified as AV1/480p and shipped, silent, with a
+                # duplicated video stream. The chunk path always guarded this;
+                # the whole-file path did not.
+                audio_map = ['-map', f'0:{audio_index}'] if audio_index is not None else []
+                if audio_index is None:
+                    log(worker_id, "Source has no audio stream — encoding video only.", "WARN")
                 if _is_local:
-                    cmd = [FFMPEG_CMD, '-y', '-i', dl_url,
-                           '-map', '0:v:0', '-map', f'0:{audio_index}']
+                    cmd = [FFMPEG_CMD, '-y', '-i', dl_url, '-map', '0:v:0'] + audio_map
                 else:
                     cmd = [FFMPEG_CMD,
                            '-headers', ffmpeg_http_headers,
                            '-reconnect', '1', '-reconnect_streamed', '1', '-reconnect_delay_max', '60',
                            '-reconnect_on_network_error', '1',
-                           '-y', '-i', dl_url, '-map', '0:v:0', '-map', f'0:{audio_index}']
+                           '-y', '-i', dl_url, '-map', '0:v:0'] + audio_map
                 for idx in subtitle_indices: cmd.extend(['-map', f'0:{idx}'])
                 
                 cmd.extend([


### PR DESCRIPTION
## The defect

54 of 1775 completed files carry **two full-length AV1 video streams and no audio** — they pass every existing check (AV1, 480p, correct duration) and play silently.

I reproduced the exact reported stream layout locally and traced it to a bug on **both** sides:

**Worker.** The whole-file command mapped audio unconditionally:

```python
'-map', '0:v:0', '-map', f'0:{audio_index}'     # audio_index defaults to 0
```

When the probe found no audio streams, `audio_index` stayed at its initial `0`, so this expanded to `-map 0:v:0 -map 0:0` — **the video mapped twice**. The chunk path always guarded this (`if audio_index is not None`); the whole-file path never did. The resume path had the same `.get('audio_index', 0)` default.

**Manager.** `verify_upload` only required *a* video stream — nothing rejected a second one or a missing audio track, so the defect shipped 54 times.

## Fixes

- **Worker (3.4.8):** `audio_index` is `None` when there is no audio, and the audio map is omitted entirely (with a log line). Resume path fixed the same way.
- **Manager:** `verify_upload` now rejects **>1 video stream** (never a valid target layout, and the precise signature of this bug) and rejects an upload with **no audio when the source is known to have audio**, using the `stream_meta` the manager already records. Wired into both whole-file upload and chunk-assembly verification.

## Recovery tool

New **`retry_purge`** admin action: deletes the finished encode, drops chunk rows **and banked chunk files** (so defective chunks can't be restored into the retry via the #28 banking), and requeues with `fail_count` reset. Exposed as a **RE-ENC** button on completed jobs, and returns `{"requeued": bool}` so bulk callers can confirm each one.

## Note on the batch

The report suggested "a single contiguous failed batch". The DB says otherwise: all 52 still-completed jobs were encoded by **worker 3.0.26 across 11 different volunteer nodes** between April and May 2026 (`Birdman3131`, `fie-K0r3_7_Ul7ra`, `Corsair`, `FractumG14`, `DTower`). It's a version-wide bug — the alphabetical clustering is just the queue order during the window that version was deployed. (2 of the 54 are already back in the queue.)

## Verification

- Built a real file with the reported layout (`0,av1,video` / `1,av1,video`) → now rejected; a legitimately audio-less source still passes; a silent file whose source *has* audio is rejected.
- `retry_purge` against a seeded completed job with a planted output + banked chunks: output deleted, chunk rows and chunk dir gone, job back to `queued` with `fail_count=0`; unknown id returns `requeued=false` without error.
- Worker command construction verified to produce no duplicate map, with and without audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014irAD7sEUoXyCw4k44AiFm)_